### PR TITLE
add source location info to assembler/emulator

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,6 +12,7 @@ Assembler
   [x] maybe switch from hashtable to different map
   [x] reconsider how we validate immediates: currently prevents you
     from writing an immediate that is a mem loc >127
+  [x] track source locations for error messages
 
 Compiler
   [x] decide on language constructs

--- a/lang/asm/isa.ml
+++ b/lang/asm/isa.ml
@@ -1,4 +1,5 @@
 open Printf
+open Util.Srcloc
 
 (* Programmer-facing registers: A, B, C, and stack pointer *)
 type register = A | B | C | SP

--- a/lang/asm/lex.mll
+++ b/lang/asm/lex.mll
@@ -1,7 +1,7 @@
 {
   open Parse
   open Util.Srcloc
-  exception Error of string
+  exception Error of string * src_loc
 }
 
 rule token = parse
@@ -9,13 +9,8 @@ rule token = parse
   { token lexbuf }
 | ';'[^'\n']*?
   { token lexbuf }
-| '\n' { 
-  let pos = lexbuf.lex_curr_p in 
-  lexbuf.lex_curr_p <- 
-  {
-    pos with pos_bol = lexbuf.lex_curr_pos;
-    pos_lnum = pos.pos_lnum + 1
-  };
+| '\n' {
+  Lexing.new_line lexbuf; 
   NEWLINE }
 | ':' { COLON }
 | ',' { COMMA }
@@ -108,8 +103,10 @@ rule token = parse
 | eof
     { EOF }
 | _
-    { raise (Error (Printf.sprintf 
-      "unexpected character '%s' at position %d:%d" 
-      (Lexing.lexeme lexbuf)
-      (Lexing.lexeme_start_p lexbuf).pos_lnum
-      (Lexing.lexeme_start lexbuf))) }
+    { raise (Error 
+      ((Printf.sprintf 
+        "unexpected character '%s' at position %d:%d" 
+        (String.escaped (Lexing.lexeme lexbuf))
+        (Lexing.lexeme_start_p lexbuf).pos_lnum
+        (Lexing.lexeme_start lexbuf)), 
+      (loc_from_lexbuf lexbuf))) }

--- a/lang/asm/lex.mll
+++ b/lang/asm/lex.mll
@@ -1,5 +1,6 @@
 {
   open Parse
+  open Util.Srcloc
   exception Error of string
 }
 
@@ -33,77 +34,77 @@ rule token = parse
 | "sp"
   { REG_SP }
 | "add"
-  { ADD }
+  { ADD (loc_from_lexbuf lexbuf) }
 | "addi"
-  { ADDI }
+  { ADDI (loc_from_lexbuf lexbuf) }
 | "sub"
-  { SUB }
+  { SUB (loc_from_lexbuf lexbuf) }
 | "subi"
-  { SUBI }
+  { SUBI (loc_from_lexbuf lexbuf) }
 | "and"
-  { AND }
+  { AND (loc_from_lexbuf lexbuf) }
 | "ani"
-  { ANI }
+  { ANI (loc_from_lexbuf lexbuf) }
 | "or"
-  { OR }
+  { OR (loc_from_lexbuf lexbuf) }
 | "ori"
-  { ORI }
+  { ORI (loc_from_lexbuf lexbuf) }
 | "xor"
-  { XOR }
+  { XOR (loc_from_lexbuf lexbuf) }
 | "xri"
-  { XRI }
+  { XRI (loc_from_lexbuf lexbuf) }
 | "not"
-  { NOT }
+  { NOT (loc_from_lexbuf lexbuf) }
 | "inr"
-  { INR }
+  { INR (loc_from_lexbuf lexbuf) }
 | "dcr"
-  { DCR }
+  { DCR (loc_from_lexbuf lexbuf) }
 | "mov"
-  { MOV }
+  { MOV (loc_from_lexbuf lexbuf) }
 | "mvi"
-  { MVI }
+  { MVI (loc_from_lexbuf lexbuf) }
 | "ld"
-  { LD }
+  { LD (loc_from_lexbuf lexbuf) }
 | "st"
-  { ST }
+  { ST (loc_from_lexbuf lexbuf) }
 | "lds"
-  { LDS }
+  { LDS (loc_from_lexbuf lexbuf) }
 | "sts"
-  { STS }
+  { STS (loc_from_lexbuf lexbuf) }
 | "cmp"
-  { CMP }
+  { CMP (loc_from_lexbuf lexbuf) }
 | "cmpi"
-  { CMPI }
+  { CMPI (loc_from_lexbuf lexbuf) }
 | "jmp"
-  { JMP }
+  { JMP (loc_from_lexbuf lexbuf) }
 | "je"
-  { JE }
+  { JE (loc_from_lexbuf lexbuf) }
 | "jne"
-  { JNE }
+  { JNE (loc_from_lexbuf lexbuf) }
 | "jg"
-  { JG }
+  { JG (loc_from_lexbuf lexbuf) }
 | "jge"
-  { JGE }
+  { JGE (loc_from_lexbuf lexbuf) }
 | "jl"
-  { JL }
+  { JL (loc_from_lexbuf lexbuf) }
 | "jle"
-  { JLE }
+  { JLE (loc_from_lexbuf lexbuf) }
 | "call"
-  { CALL }
+  { CALL (loc_from_lexbuf lexbuf) }
 | "ret"
-  { RET }
+  { RET (loc_from_lexbuf lexbuf) }
 | "dic"
-  { DIC }
+  { DIC (loc_from_lexbuf lexbuf) }
 | "did"
-  { DID }
+  { DID (loc_from_lexbuf lexbuf) }
 | "hlt"
-  { HLT }
+  { HLT (loc_from_lexbuf lexbuf) }
 | "nop"
-  { NOP }
+  { NOP (loc_from_lexbuf lexbuf) }
 | "out"
-  { OUT }
+  { OUT (loc_from_lexbuf lexbuf) }
 | ['a'-'z''A'-'Z']['a'-'z''A'-'Z''_''0'-'9']* as name
-    { LABEL name }
+    { LABEL (name, (loc_from_lexbuf lexbuf)) }
 | eof
     { EOF }
 | _

--- a/lang/asm/parse.mly
+++ b/lang/asm/parse.mly
@@ -1,5 +1,6 @@
 %{ 
   open Isa
+  open Util.Srcloc
 %}
 
 %token <int> IMM
@@ -7,49 +8,49 @@
 %token REG_B
 %token REG_C
 %token REG_SP
-%token ADD
-%token ADDI
-%token SUB
-%token SUBI
-%token AND
-%token ANI
-%token OR
-%token ORI
-%token XOR
-%token XRI
-%token NOT
-%token INR
-%token DCR
-%token MOV
-%token MVI
-%token LD
-%token ST
-%token LDS
-%token STS
-%token CMP
-%token CMPI
-%token JMP
-%token JE
-%token JNE
-%token JG
-%token JGE
-%token JL
-%token JLE
-%token CALL
-%token RET
-%token DIC
-%token DID
-%token HLT
-%token NOP
-%token OUT
-%token <string> LABEL
+%token <Util.Srcloc.src_loc> ADD
+%token <Util.Srcloc.src_loc> ADDI
+%token <Util.Srcloc.src_loc> SUB
+%token <Util.Srcloc.src_loc> SUBI
+%token <Util.Srcloc.src_loc> AND
+%token <Util.Srcloc.src_loc> ANI
+%token <Util.Srcloc.src_loc> OR
+%token <Util.Srcloc.src_loc> ORI
+%token <Util.Srcloc.src_loc> XOR
+%token <Util.Srcloc.src_loc> XRI
+%token <Util.Srcloc.src_loc> NOT
+%token <Util.Srcloc.src_loc> INR
+%token <Util.Srcloc.src_loc> DCR
+%token <Util.Srcloc.src_loc> MOV
+%token <Util.Srcloc.src_loc> MVI
+%token <Util.Srcloc.src_loc> LD
+%token <Util.Srcloc.src_loc> ST
+%token <Util.Srcloc.src_loc> LDS
+%token <Util.Srcloc.src_loc> STS
+%token <Util.Srcloc.src_loc> CMP
+%token <Util.Srcloc.src_loc> CMPI
+%token <Util.Srcloc.src_loc> JMP
+%token <Util.Srcloc.src_loc> JE
+%token <Util.Srcloc.src_loc> JNE
+%token <Util.Srcloc.src_loc> JG
+%token <Util.Srcloc.src_loc> JGE
+%token <Util.Srcloc.src_loc> JL
+%token <Util.Srcloc.src_loc> JLE
+%token <Util.Srcloc.src_loc> CALL
+%token <Util.Srcloc.src_loc> RET
+%token <Util.Srcloc.src_loc> DIC
+%token <Util.Srcloc.src_loc> DID
+%token <Util.Srcloc.src_loc> HLT
+%token <Util.Srcloc.src_loc> NOP
+%token <Util.Srcloc.src_loc> OUT
+%token <string * Util.Srcloc.src_loc> LABEL
 
 %token COLON
 %token COMMA
 %token NEWLINE
 %token EOF
 
-%start <instr list> main
+%start <instr with_loc list> main
 
 %%
 
@@ -76,77 +77,86 @@ reg:
   { SP }
 
 instr:
-| ADD src = reg COMMA dest = reg
-  { Add(src, dest) }
-| ADDI src = IMM COMMA dest = reg
-  { Addi(src, dest) }
-| SUB src = reg COMMA dest = reg
-  { Sub(src, dest) }
-| SUBI src = IMM COMMA dest = reg
-  { Subi(src, dest) }
-| AND src = reg COMMA dest = reg
-  { And(src, dest) }
-| ANI src = IMM COMMA dest = reg
-  { Ani(src, dest) }
-| OR src = reg COMMA dest = reg
-  { Or(src, dest) }
-| ORI src = IMM COMMA dest = reg
-  { Ori(src, dest) }
-| XOR src = reg COMMA dest = reg
-  { Xor(src, dest) }
-| XRI src = IMM COMMA dest = reg
-  { Xri(src, dest) }
-| NOT r = reg
-  { Not r }
-| INR r = reg
-  { Inr r }
-| DCR r = reg
-  { Dcr r }
-| MOV src = reg COMMA dest = reg
-  { Mov(src, dest) }
-| MVI src = IMM COMMA dest = reg
-  { Mvi(src, dest) }
-| LD src = reg COMMA dest = reg
-  { Ld(src, dest) }
-| ST src = reg COMMA dest = reg
-  { St(src, dest) }
-| LDS src = IMM COMMA dest = reg
-  { Lds(src, dest) }
-| STS src = reg COMMA dest = IMM
-  { Sts(src, dest) }
-| CMP left = reg COMMA right = reg
-  { Cmp(left, right) }
-| CMPI left = IMM COMMA right = reg
-  { Cmpi(Imm left, Reg right) }
-| CMPI left = reg COMMA right = IMM
-  { Cmpi(Reg left, Imm right) }
-| lb = LABEL COLON
-  { Label lb }
-| JMP target = LABEL
-  { Jmp target }
-| JE target = LABEL
-  { Je target }
-| JNE target = LABEL
-  { Jne target }
-| JG target = LABEL
-  { Jg target }
-| JGE target = LABEL
-  { Jge target }
-| JL target = LABEL
-  { Jl target }
-| JLE target = LABEL
-  { Jle target }
-| CALL target = LABEL
-  { Call target }
-| RET
-  { Ret }
-| DIC imm = IMM
-  { Dic imm }
-| DID imm = IMM
-  { Did imm }
-| HLT
-  { Hlt }
-| NOP
-  { Nop }
-| OUT r = reg
-  { Out r }
+| loc = ADD src = reg COMMA dest = reg
+  { (Add(src, dest), loc) }
+| loc = ADDI src = IMM COMMA dest = reg
+  { (Addi(src, dest), loc) }
+| loc = SUB src = reg COMMA dest = reg
+  { (Sub(src, dest), loc) }
+| loc = SUBI src = IMM COMMA dest = reg
+  { (Subi(src, dest), loc) }
+| loc = AND src = reg COMMA dest = reg
+  { (And(src, dest), loc) }
+| loc = ANI src = IMM COMMA dest = reg
+  { (Ani(src, dest), loc) }
+| loc = OR src = reg COMMA dest = reg
+  { (Or(src, dest), loc) }
+| loc = ORI src = IMM COMMA dest = reg
+  { (Ori(src, dest), loc) }
+| loc = XOR src = reg COMMA dest = reg
+  { (Xor(src, dest), loc) }
+| loc = XRI src = IMM COMMA dest = reg
+  { (Xri(src, dest), loc) }
+| loc = NOT r = reg
+  { (Not r, loc) }
+| loc = INR r = reg
+  { (Inr r, loc) }
+| loc = DCR r = reg
+  { (Dcr r, loc) }
+| loc = MOV src = reg COMMA dest = reg
+  { (Mov(src, dest), loc) }
+| loc = MVI src = IMM COMMA dest = reg
+  { (Mvi(src, dest), loc) }
+| loc = LD src = reg COMMA dest = reg
+  { (Ld(src, dest), loc) }
+| loc = ST src = reg COMMA dest = reg
+  { (St(src, dest), loc) }
+| loc = LDS src = IMM COMMA dest = reg
+  { (Lds(src, dest), loc) }
+| loc = STS src = reg COMMA dest = IMM
+  { (Sts(src, dest), loc) }
+| loc = CMP left = reg COMMA right = reg
+  { (Cmp(left, right), loc) }
+| loc = CMPI left = IMM COMMA right = reg
+  { (Cmpi(Imm left, Reg right), loc) }
+| loc = CMPI left = reg COMMA right = IMM
+  { (Cmpi(Reg left, Imm right), loc) }
+| label = LABEL COLON
+  { let (label, loc) = label in 
+    (Label label, loc) }
+| loc = JMP target = LABEL
+  { let (target, _) = target in 
+    (Jmp target, loc) }
+| loc = JE target = LABEL
+  { let (target, _) = target in 
+    (Je target, loc) }
+| loc = JNE target = LABEL
+  { let (target, _) = target in 
+    (Jne target, loc) }
+| loc = JG target = LABEL
+  { let (target, _) = target in 
+    (Jg target, loc) }
+| loc = JGE target = LABEL
+  { let (target, _) = target in 
+    (Jge target, loc) }
+| loc = JL target = LABEL
+  { let (target, _) = target in 
+    (Jl target, loc) }
+| loc = JLE target = LABEL
+  { let (target, _) = target in 
+    (Jle target, loc) }
+| loc = CALL target = LABEL
+  { let (target, _) = target in 
+    (Call target, loc) }
+| loc = RET
+  { (Ret, loc) }
+| loc = DIC imm = IMM
+  { (Dic imm, loc) }
+| loc = DID imm = IMM
+  { (Did imm, loc) }
+| loc = HLT
+  { (Hlt, loc) }
+| loc = NOP
+  { (Nop, loc) }
+| loc = OUT r = reg
+  { (Out r, loc) }

--- a/lang/asm/parser.ml
+++ b/lang/asm/parser.ml
@@ -3,7 +3,7 @@ open Printf
 open Isa
 open Util.Srcloc
 
-exception AsmParseError of string
+exception AsmParseError of string * src_loc
 
 (* [parse] consumes a string representing an assembly program
   and parses it into a list of instructions with source location info *)
@@ -11,10 +11,12 @@ let parse (s : string) : instr with_loc list =
   let buf = Lexing.from_string s in
   match Parse.main Lex.token buf with
   | instrs -> instrs
-  | exception Lex.Error msg -> raise (AsmParseError msg)
+  | exception Lex.Error (msg, loc) -> raise (AsmParseError (msg, loc))
   | exception Parse.Error ->
       let pos = Lexing.lexeme_start_p buf in
       let msg =
-        sprintf "bad token '%s' on line %d" (Lexing.lexeme buf) pos.pos_lnum
+        sprintf "bad token '%s' on line %d"
+          (String.escaped (Lexing.lexeme buf))
+          pos.pos_lnum
       in
-      raise (AsmParseError msg)
+      raise (AsmParseError (msg, loc_from_lexbuf buf))

--- a/lang/asm/parser.ml
+++ b/lang/asm/parser.ml
@@ -1,9 +1,11 @@
 open Stdlib
 open Printf
+open Isa
+open Util.Srcloc
 
 exception AsmParseError of string
 
-let parse (s : string) =
+let parse (s : string) : instr with_loc list =
   let buf = Lexing.from_string s in
   match Parse.main Lex.token buf with
   | instrs -> instrs

--- a/lang/asm/parser.ml
+++ b/lang/asm/parser.ml
@@ -5,6 +5,8 @@ open Util.Srcloc
 
 exception AsmParseError of string
 
+(* [parse] consumes a string representing an assembly program
+  and parses it into a list of instructions with source location info *)
 let parse (s : string) : instr with_loc list =
   let buf = Lexing.from_string s in
   match Parse.main Lex.token buf with

--- a/lang/bin/assemble.ml
+++ b/lang/bin/assemble.ml
@@ -36,10 +36,11 @@ let command =
             (Bytes.length assembled);
           printf_bytes assembled
         with
-        | Assemble.AssembleError err ->
-            Printf.eprintf "%s: %s\n"
+        | Assemble.AssembleError (err, maybe_loc) ->
+            Printf.eprintf "%s: %s\n%s\n"
               (Colors.error "Assembler Error")
               (Assemble.string_of_asm_err err)
+              (Srcloc.string_of_maybe_loc maybe_loc)
         | Parser.AsmParseError msg ->
             Printf.eprintf "%s: %s\n" (Colors.error "Error Parsing Asm") msg
         | err ->

--- a/lang/bin/assemble.ml
+++ b/lang/bin/assemble.ml
@@ -40,7 +40,8 @@ let command =
             Printf.eprintf "%s: %s\n%s\n"
               (Colors.error "Assembler Error")
               (Assemble.string_of_asm_err err)
-              (Srcloc.string_of_maybe_loc maybe_loc)
+              (Srcloc.string_of_maybe_loc maybe_loc
+                 (In_channel.read_all asm_filename))
         | Parser.AsmParseError msg ->
             Printf.eprintf "%s: %s\n" (Colors.error "Error Parsing Asm") msg
         | err ->

--- a/lang/bin/dune
+++ b/lang/bin/dune
@@ -3,14 +3,19 @@
   (modules assemble)
   (preprocess
     (pps ppx_let))
-  (libraries core asm util))
+  (libraries core asm util errors))
 
 (executable
   (name emulate)
   (modules emulate)
   (preprocess
     (pps ppx_let))
-  (libraries core asm util emulator))
+  (libraries core asm util emulator errors))
+
+(library
+  (name errors)
+  (modules errors)
+  (libraries core util))
 
 (env
   (dev

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -26,10 +26,12 @@ let command =
         with
         | Parser.AsmParseError msg ->
             eprintf "%s: %s\n" (Colors.error "Error Parsing Asm") msg
-        | EmulatorError err ->
-            eprintf "%s: %s\n"
+        | EmulatorError (err, maybe_loc) ->
+            eprintf "%s: %s\n%s\n"
               (Colors.error "Emulator Error")
               (string_of_emu_err err)
+              (Srcloc.string_of_maybe_loc maybe_loc
+                 (In_channel.read_all filename))
         | err -> eprintf "%s: %s\n" (Colors.error "Error") (Exn.to_string err))
 
 let () = Command.run ~version:"1.0" command

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -3,6 +3,7 @@ open Asm
 open Emulator
 open Util
 open Printf
+open Errors
 
 (* command-line interface for emulator *)
 let command =
@@ -16,22 +17,26 @@ let command =
         let verbosity = match verbosity with None -> 0 | Some v -> v in
         try
           (* read input file into string *)
-          let text = In_channel.read_all filename in
-          (* parse input program *)
-          let instrs = Parser.parse text in
-          (* emulate and print final state *)
-          let final_state = emulate instrs verbosity in
-          printf "%s\n" (Colors.bold "Halted via hlt!");
-          printf "%s\n" (string_of_stew_3000 final_state)
-        with
-        | Parser.AsmParseError msg ->
-            eprintf "%s: %s\n" (Colors.error "Error Parsing Asm") msg
-        | EmulatorError (err, maybe_loc) ->
-            eprintf "%s: %s\n%s\n"
-              (Colors.error "Emulator Error")
-              (string_of_emu_err err)
-              (Srcloc.string_of_maybe_loc maybe_loc
-                 (In_channel.read_all filename))
-        | err -> eprintf "%s: %s\n" (Colors.error "Error") (Exn.to_string err))
+          let source_text = In_channel.read_all filename in
+          try
+            (* parse input program *)
+            let instrs = Parser.parse source_text in
+            (* emulate and print final state *)
+            let final_state = emulate instrs verbosity in
+            printf "%s\n" (Colors.bold "Halted via hlt!");
+            printf "%s\n" (string_of_stew_3000 final_state)
+          with
+          | Parser.AsmParseError (msg, loc) ->
+              print_err
+                (Colors.error "Error Parsing Asm")
+                msg
+                (Srcloc.string_of_src_loc loc source_text)
+          | EmulatorError (err, maybe_loc) ->
+              print_err
+                (Colors.error "Emulator Error")
+                (string_of_emu_err err)
+                (Srcloc.string_of_maybe_loc maybe_loc source_text)
+          | err -> print_arbitrary_err err
+        with err -> print_arbitrary_err err)
 
 let () = Command.run ~version:"1.0" command

--- a/lang/bin/errors.ml
+++ b/lang/bin/errors.ml
@@ -1,0 +1,12 @@
+open Core
+open Util
+
+(* [print_arbitrary_err] prints an arbitrary exception type 
+    as a string error message to stderr *)
+let print_arbitrary_err (error : exn) =
+  Printf.eprintf "%s: %s\n" (Colors.error "Error") (Exn.to_string error)
+
+(* [print_err] prints an error to stderr, given a type, message,
+    and source location string *)
+let print_err (err_type : string) (msg : string) (loc : string) =
+  Printf.eprintf "%s: %s\n%s\n" err_type msg loc

--- a/lang/emulator/emulator.ml
+++ b/lang/emulator/emulator.ml
@@ -92,11 +92,11 @@ exception EmulatorError of emu_err with_loc_opt
 
 let string_of_emu_err (err : emu_err) =
   match err with
-  | DuplicateLabel label -> sprintf "duplicate label: %s" label
+  | DuplicateLabel label -> sprintf "label `%s` appears more than once" label
   | InvalidProgramCounter machine ->
       sprintf "invalid program counter: %d\n%s" machine.pc
         (string_of_stew_3000 machine)
-  | InvalidTarget label -> sprintf "invalid target: %s" label
+  | InvalidTarget label -> sprintf "invalid target: `%s`" label
   | InvalidImm imm -> sprintf "invalid immediate value: %s" (string_of_imm imm)
   | InvalidInstr ins -> sprintf "invalid instruction: %s" (string_of_instr ins)
   | InvalidStackAccess (loc, machine) ->

--- a/lang/emulator/emulator.ml
+++ b/lang/emulator/emulator.ml
@@ -2,6 +2,7 @@ open Asm.Isa
 open Asm.Validate
 open Printf
 open Util.Env
+open Util.Srcloc
 open Util
 
 (*  stew_3000 models the programmer-visible state of the machine
@@ -87,7 +88,7 @@ type emu_err =
   | InvalidInstr of instr
   | InvalidStackAccess of int * stew_3000
 
-exception EmulatorError of emu_err
+exception EmulatorError of emu_err with_loc_opt
 
 let string_of_emu_err (err : emu_err) =
   match err with
@@ -104,8 +105,9 @@ let string_of_emu_err (err : emu_err) =
 
 (* [emulate_instr] emulates the effect of the given instruction
   on the machine, by mutating the machine in-place *)
-let emulate_instr (ins : instr) (machine : stew_3000) (label_map : int env)
-    (verbosity : int) =
+let emulate_instr (ins : instr with_loc) (machine : stew_3000)
+    (label_map : int env) (verbosity : int) =
+  let ins, srcloc = ins in
   (* [load_reg] retrieves the value currently stored in a register *)
   let load_reg (reg : register) : int =
     match reg with
@@ -127,21 +129,21 @@ let emulate_instr (ins : instr) (machine : stew_3000) (label_map : int env)
   let load_stack (loc : int) : int =
     try Array.get machine.stack loc
     with Invalid_argument _ ->
-      raise (EmulatorError (InvalidStackAccess (loc, machine)))
+      raise (EmulatorError (InvalidStackAccess (loc, machine), Some srcloc))
   in
   (* [store_stack] writes a given value to the stack at a given
      location, or errors if the access is bad *)
   let store_stack (loc : int) (value : int) =
     try Array.set machine.stack loc value
     with Invalid_argument _ ->
-      raise (EmulatorError (InvalidStackAccess (loc, machine)))
+      raise (EmulatorError (InvalidStackAccess (loc, machine), Some srcloc))
   in
   (* [label_to_index] converts a string label to its corresponding index,
      erroring if there is no index for the label *)
   let label_to_index (label : string) =
     match Env.find_opt label label_map with
     | Some index -> index
-    | None -> raise (EmulatorError (InvalidTarget label))
+    | None -> raise (EmulatorError (InvalidTarget label, Some srcloc))
   in
   (* [as_8bit_signed] checks if a value has 8-bit signed overflow,
      and keeps it within the representable range [-128, 128),
@@ -215,9 +217,11 @@ let emulate_instr (ins : instr) (machine : stew_3000) (label_map : int env)
   in
 
   (* first, ensure that the instruction is valid *)
-  (try validate_instr ins with
-  | ValidityError (InvalidImm imm) -> raise (EmulatorError (InvalidImm imm))
-  | ValidityError (InvalidInstr ins) -> raise (EmulatorError (InvalidInstr ins)));
+  (try validate_instr (ins, srcloc) with
+  | ValidityError (InvalidImm imm, maybe_loc) ->
+      raise (EmulatorError (InvalidImm imm, maybe_loc))
+  | ValidityError (InvalidInstr ins, maybe_loc) ->
+      raise (EmulatorError (InvalidInstr ins, maybe_loc)));
 
   (* simulate the effects of the instruction*)
   match ins with
@@ -292,49 +296,50 @@ let emulate_instr (ins : instr) (machine : stew_3000) (label_map : int env)
   | Label _ | Nop -> inc_pc ()
   (* XXX: Dic and Did not currently supported *)
   | Dic _ | Did _ -> inc_pc ()
-  | _ -> raise (EmulatorError (InvalidInstr ins))
+  | _ -> raise (EmulatorError (InvalidInstr ins, Some srcloc))
 
 (* [map_labels] constructs an environment that maps label names to indices in
   the program's list of instructions *)
-let map_labels (instrs : instr list) =
+let map_labels (instrs : instr with_loc list) =
   (* pair instructions with their indices in the program *)
   List.mapi (fun i ins -> (i, ins)) instrs
   (* accumulate an environment of labels->indices *)
   |> List.fold_left
-       (fun env (i, ins) ->
+       (fun env (i, (ins, loc)) ->
          match ins with
          | Label name ->
              (* map each label to the index following it *)
              if Env.mem name env then
-               raise (EmulatorError (DuplicateLabel name))
+               raise (EmulatorError (DuplicateLabel name, Some loc))
              else Env.add name (i + 1) env
          | _ -> env)
        Env.empty
 
 (* [get_current_ins] retrieves the current instruction to execute 
   by indexing into the program using the machine's program counter *)
-let get_current_ins (pgrm : instr list) (machine : stew_3000) : instr =
+let get_current_ins (pgrm : instr with_loc list) (machine : stew_3000) :
+    instr with_loc =
   try List.nth pgrm machine.pc
   with Failure _ | Invalid_argument _ ->
-    raise (EmulatorError (InvalidProgramCounter machine))
+    raise (EmulatorError (InvalidProgramCounter machine, None))
 
 (* [emulate] emulates running the given assembly program 
   on the Stew 3000, and returns the final machine state after the run.
   verbosity indicates how much logging should happen during the run. *)
-let emulate (pgrm : instr list) (verbosity : int) : stew_3000 =
+let emulate (pgrm : instr with_loc list) (verbosity : int) : stew_3000 =
   let machine = new_stew_3000 () in
   let label_map = map_labels pgrm in
   let rec run _ =
     if machine.halted then ()
     else
-      let ins = get_current_ins pgrm machine in
+      let ins, loc = get_current_ins pgrm machine in
       (* verbosity level 2, current instruction is logged *)
       if verbosity >= 2 then
         printf "%s %s\n"
           (Colors.log "[current instruction]")
           (string_of_instr ins)
       else ();
-      emulate_instr ins machine label_map verbosity;
+      emulate_instr (ins, loc) machine label_map verbosity;
       (* verbosity level 3, entire machine state is logged *)
       if verbosity >= 3 then
         printf "%s\n%s"

--- a/lang/test/test_compiler.ml
+++ b/lang/test/test_compiler.ml
@@ -3,10 +3,13 @@ open Compiler.Compile
 open Compiler.Ast
 open Asm.Isa
 open Emulator
+open Util.Srcloc
+
+let dummy_src_loc = loc 0 0
 
 let compile_and_run (pgrm : prog) : stew_3000 =
   let instrs = compile pgrm in
-  emulate instrs 0
+  emulate (List.map (fun ins -> (ins, dummy_src_loc)) instrs) 0
 
 let test_simple_pgrm _ =
   let machine = compile_and_run { funcs = []; main = [ ExprStmt (Num 7) ] } in

--- a/lang/util/colors.ml
+++ b/lang/util/colors.ml
@@ -2,23 +2,26 @@ open Printf
 
 (* [effect] produces a string which has the effect specified
     by the given ANSI color code applied to it *)
-let effect (code : string) (s : string) : string =
-  sprintf "\027[%sm%s\027[0m" code s
+let effect (code : string) (s : string) = sprintf "\027[%sm%s\027[0m" code s
 
-let bold (s : string) : string = effect "1" s
+let bold s = effect "1" s
 
-let red (s : string) : string = effect "31" s
+let red s = effect "31" s
 
-let br_red (s : string) : string = effect "31;1" s
+let br_red s = effect "31;1" s
 
-let br_cyan (s : string) : string = effect "36;1" s
+let br_cyan s = effect "36;1" s
 
-let br_green (s : string) : string = effect "32;1" s
+let br_green s = effect "32;1" s
 
-let br_blue (s : string) : string = effect "94" s
+let br_blue s = effect "94" s
 
-let error (s : string) : string = bold (br_red s)
+let br_black s = effect "90" s
 
-let success (s : string) : string = bold (br_green s)
+let white s = effect "37" s
 
-let log (s : string) : string = bold (br_blue s)
+let error s = bold (br_red s)
+
+let success s = bold (br_green s)
+
+let log s = bold (br_blue s)

--- a/lang/util/srcloc.ml
+++ b/lang/util/srcloc.ml
@@ -6,6 +6,9 @@ type src_loc = { startl : int; endl : int }
 (* with_loc describes a type that has a src location attached to it *)
 type 'a with_loc = 'a * src_loc
 
+(* with_loc_opt describes a type that might have a src location attached *)
+type 'a with_loc_opt = 'a * src_loc option
+
 (* [loc] generates a new src_loc record with 
   the given start and ending line *)
 let loc (startl : int) (endl : int) = { startl; endl }
@@ -14,3 +17,8 @@ let loc (startl : int) (endl : int) = { startl; endl }
   the current line position of the lexing buffer *)
 let loc_from_lexbuf (buf : lexbuf) =
   loc buf.lex_curr_p.pos_lnum buf.lex_curr_p.pos_lnum
+
+let string_of_src_loc (loc : src_loc) : string = ""
+
+let string_of_maybe_loc (loc : src_loc option) : string =
+  match loc with None -> "" | Some loc -> string_of_src_loc loc

--- a/lang/util/srcloc.ml
+++ b/lang/util/srcloc.ml
@@ -18,7 +18,12 @@ let loc (startl : int) (endl : int) = { startl; endl }
 let loc_from_lexbuf (buf : lexbuf) =
   loc buf.lex_curr_p.pos_lnum buf.lex_curr_p.pos_lnum
 
-let string_of_src_loc (loc : src_loc) : string = ""
+(* [string_of_src_loc] converts a source location and a source file 
+  contents into a message indicating the position in the source file *)
+let string_of_src_loc (loc : src_loc) (source : string) : string =
+  "TODO: SOURCE LOC"
 
-let string_of_maybe_loc (loc : src_loc option) : string =
-  match loc with None -> "" | Some loc -> string_of_src_loc loc
+(* [string_of_maybe_loc] is a wrapper for string of src loc that handles 
+  optional locations *)
+let string_of_maybe_loc (loc : src_loc option) (source : string) : string =
+  match loc with None -> "" | Some loc -> string_of_src_loc loc source

--- a/lang/util/srcloc.ml
+++ b/lang/util/srcloc.ml
@@ -1,6 +1,5 @@
 open Lexing
 open Printf
-open Colors
 
 (* src_loc describes a range of line numbers in a source file *)
 type src_loc = { startl : int; endl : int }
@@ -18,7 +17,8 @@ let loc (startl : int) (endl : int) = { startl; endl }
 (* [loc_from_lexbuf] constructs a src loc from
   the current line position of the lexing buffer *)
 let loc_from_lexbuf (buf : lexbuf) =
-  loc buf.lex_curr_p.pos_lnum buf.lex_curr_p.pos_lnum
+  let lno = (lexeme_start_p buf).pos_lnum in
+  loc lno lno
 
 (* the periphery is how many lines above and below the source 
   location are printed when the location is printed *)

--- a/lang/util/srcloc.ml
+++ b/lang/util/srcloc.ml
@@ -1,0 +1,16 @@
+open Lexing
+
+(* src_loc describes a range of line numbers in a source file *)
+type src_loc = { startl : int; endl : int }
+
+(* with_loc describes a type that has a src location attached to it *)
+type 'a with_loc = 'a * src_loc
+
+(* [loc] generates a new src_loc record with 
+  the given start and ending line *)
+let loc (startl : int) (endl : int) = { startl; endl }
+
+(* [loc_from_lexbuf] constructs a src loc from
+  the current line position of the lexing buffer *)
+let loc_from_lexbuf (buf : lexbuf) =
+  loc buf.lex_curr_p.pos_lnum buf.lex_curr_p.pos_lnum


### PR DESCRIPTION
This adds tracking of source locations (line number ranges) in the asm parser, which leads to significantly better error messages in both the assembler and emulator.

![Screenshot from 2021-05-13 21-15-18](https://user-images.githubusercontent.com/13399527/118206370-59071b80-b430-11eb-9471-2286de40e9f6.png)

The source location utilities are in `util/srcloc.ml`.