### PR TITLE
emulator overhaul

### DIFF
--- a/TODO
+++ b/TODO
@@ -37,6 +37,6 @@ Emulator
   [x] bin/emulate can now throw assemble errors
   [x] display registers in decimal/hex/binary
   [] "step" mode for emulator for debugging
-    [] simple command language?
+    [] simple command language
 
 [] document everything

--- a/TODO
+++ b/TODO
@@ -28,10 +28,12 @@ Compiler
     [] special-case conditions (if/while)
   [] preprocessor?
 
-Virtual Machine
-  [x] software simulation of the stew3000, for compiler testing
-  [x] add flag for levels of verbose output:
-  [] (thomas): display registers in decimal/hex/binary
-  [] *future*: "step" mode for emulator for debugging?
+Emulator
+  [x] fix emulation of 8-bit integers
+  [x] rewrite overflow flag
+  [] use actual byte addresses as opposed to list indices
+  [] display registers in decimal/hex/binary
+  [] "step" mode for emulator for debugging
+    [] simple command language?
 
 [] document everything

--- a/TODO
+++ b/TODO
@@ -26,12 +26,15 @@ Compiler
     [] "compile to" given register (reduce movs)
     [] eliminate redundant instrs
     [] special-case conditions (if/while)
+    [] replace addi 1, _ / subi 1, _ with inr/dcr
+    [] remove addi 0, subi 0, etc (no effect)
   [] preprocessor?
 
 Emulator
   [x] fix emulation of 8-bit integers
   [x] rewrite overflow flag
   [] use actual byte addresses as opposed to list indices
+  [] bin/emulate can now throw assemble errors
   [] display registers in decimal/hex/binary
   [] "step" mode for emulator for debugging
     [] simple command language?

--- a/TODO
+++ b/TODO
@@ -36,7 +36,8 @@ Emulator
   [x] use actual byte addresses as opposed to list indices
   [x] bin/emulate can now throw assemble errors
   [x] display registers in decimal/hex/binary
-  [] "step" mode for emulator for debugging
-    [] simple command language
+  [x] "step" mode for emulator for debugging
+    [x] simple command language
+    [x] add shortcuts
 
 [] document everything

--- a/TODO
+++ b/TODO
@@ -33,9 +33,9 @@ Compiler
 Emulator
   [x] fix emulation of 8-bit integers
   [x] rewrite overflow flag
-  [] use actual byte addresses as opposed to list indices
-  [] bin/emulate can now throw assemble errors
-  [] display registers in decimal/hex/binary
+  [x] use actual byte addresses as opposed to list indices
+  [x] bin/emulate can now throw assemble errors
+  [x] display registers in decimal/hex/binary
   [] "step" mode for emulator for debugging
     [] simple command language?
 

--- a/lang/bin/assemble.ml
+++ b/lang/bin/assemble.ml
@@ -45,7 +45,9 @@ let command =
           try
             (* parse and assemble input program *)
             let instrs = Parser.parse source_text in
-            let assembled = Assemble.assemble instrs in
+            let _, unflattened, assembled =
+              Assemble.assemble_with_rich_info instrs
+            in
             (* write assembled binary to out file *)
             let out = Out_channel.create binary_filename in
             Out_channel.output_bytes out assembled;
@@ -60,7 +62,6 @@ let command =
             (* print side-by-side view if indicated *)
             if side_by_side then (
               Printf.printf "%s\n" (Colors.br_cyan "Side by side:");
-              let unflattened = Assemble.assemble_unflattened instrs in
               display_side_by_side instrs unflattened)
             else ()
           with

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -31,6 +31,11 @@ let command =
                 (Colors.error "Error Parsing Asm")
                 msg
                 (Srcloc.string_of_src_loc loc source_text)
+          | Assemble.AssembleError (err, maybe_loc) ->
+              print_err
+                (Colors.error "Assembler Error")
+                (Assemble.string_of_asm_err err)
+                (Srcloc.string_of_maybe_loc maybe_loc source_text)
           | EmulatorError (err, maybe_loc) ->
               print_err
                 (Colors.error "Emulator Error")

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -12,9 +12,12 @@ let command =
       let%map_open filename = anon ("filename" %: Filename.arg_type)
       and verbosity =
         flag "-v" (optional int) ~doc:"verbosity level of output logging"
-      in
+      and db_mode = flag "-3db" no_arg ~doc:"emulate in debug mode" in
       fun () ->
-        let verbosity = match verbosity with None -> 0 | Some v -> v in
+        (* debug mode puts verbosity at max *)
+        let verbosity =
+          if db_mode then 2 else match verbosity with None -> 0 | Some v -> v
+        in
         try
           (* read input file into string *)
           let source_text = In_channel.read_all filename in
@@ -22,7 +25,7 @@ let command =
             (* parse input program *)
             let instrs = Parser.parse source_text in
             (* emulate and print final state *)
-            let final_state = emulate instrs verbosity in
+            let final_state = emulate instrs verbosity db_mode in
             printf "%s\n" (Colors.bold "Halted via hlt!");
             printf "%s\n" (Emulator__Machine.string_of_stew_3000 final_state)
           with

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -24,7 +24,7 @@ let command =
             (* emulate and print final state *)
             let final_state = emulate instrs verbosity in
             printf "%s\n" (Colors.bold "Halted via hlt!");
-            printf "%s\n" (string_of_stew_3000 final_state)
+            printf "%s\n" (Emulator__Machine.string_of_stew_3000 final_state)
           with
           | Parser.AsmParseError (msg, loc) ->
               print_err

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -12,7 +12,8 @@ let command =
       let%map_open filename = anon ("filename" %: Filename.arg_type)
       and verbosity =
         flag "-v" (optional int) ~doc:"verbosity level of output logging"
-      and db_mode = flag "-3db" no_arg ~doc:"emulate in debug mode" in
+      and db_mode = flag "-3db" no_arg ~doc:"emulate in debug mode"
+      and warn = flag "-warn" no_arg ~doc:"emit warnings" in
       fun () ->
         (* debug mode puts verbosity at max *)
         let verbosity =
@@ -25,7 +26,7 @@ let command =
             (* parse input program *)
             let instrs = Parser.parse source_text in
             (* emulate and print final state *)
-            let final_state = emulate instrs verbosity db_mode in
+            let final_state = emulate instrs ~verbosity ~db_mode ~warn in
             printf "%s\n" (Colors.bold "Halted via hlt!");
             printf "%s\n" (Emulator__Machine.string_of_stew_3000 final_state)
           with

--- a/lang/emulator/ast.ml
+++ b/lang/emulator/ast.ml
@@ -12,6 +12,7 @@ type command =
   | PrintStack
   | PrintFullState
   | PrintCurrentIns
+  | PrintHalted
   | SetReg of register * int
   | SetFlag of flag * bool
   | SetStackAtAddr of int * int

--- a/lang/emulator/ast.ml
+++ b/lang/emulator/ast.ml
@@ -1,0 +1,20 @@
+type register = A | B | C | SP | PC
+
+type flag = ZF | SF | OF
+
+type command =
+  | PrintReg of register
+  | PrintFlag of flag
+  | PrintStackAtAddr of int
+  | PrintRegs
+  | PrintFlags
+  | PrintDecHistory
+  | PrintStack
+  | PrintFullState
+  | PrintCurrentIns
+  | SetReg of register * int
+  | SetFlag of flag * bool
+  | SetStackAtAddr of int * int
+  | SetHalted of bool
+  | Next
+  | NoCommand

--- a/lang/emulator/ast.ml
+++ b/lang/emulator/ast.ml
@@ -19,3 +19,4 @@ type command =
   | SetHalted of bool
   | Next
   | NoCommand
+  | Help

--- a/lang/emulator/ast.ml
+++ b/lang/emulator/ast.ml
@@ -20,3 +20,4 @@ type command =
   | Next
   | NoCommand
   | Help
+  | Clear

--- a/lang/emulator/command.ml
+++ b/lang/emulator/command.ml
@@ -2,6 +2,7 @@ open Machine
 open Asm.Isa
 open Ast
 open Parser
+open Util
 
 (* 
   Command Examples:
@@ -46,7 +47,10 @@ let exec_command (cmd : command) (machine : stew_3000) (ins : instr) =
       print_endline (string_of_dec_display machine.dec_disp_history)
   | PrintStack -> print_endline (string_of_stack machine.stack)
   | PrintFullState -> print_endline (string_of_stew_3000 machine)
-  | PrintCurrentIns -> print_endline (string_of_instr ins)
+  | PrintCurrentIns ->
+      print_endline
+        (Printf.sprintf "0x%02x %s" machine.pc (string_of_instr ins))
+  | PrintHalted -> print_endline (string_of_bool machine.halted)
   | SetReg (reg, value) -> (
       match reg with
       | A -> machine.a <- value
@@ -65,31 +69,43 @@ let exec_command (cmd : command) (machine : stew_3000) (ins : instr) =
   | SetHalted halted -> machine.halted <- halted
   | NoCommand | Next -> ()
 
-let stop_for_commands (machine : stew_3000) (ins : instr) =
+let prompt = Colors.log "(3db) "
+
+(* [loop_for_commands] loops, receiving commands from user input,
+  and executing them in the context of the current machine state
+  and instruction. It breaks out of the loop when a "next" command
+  is encountered. *)
+let loop_for_commands =
+  (* last_cmd tracks the last executed command, and is shared
+     across all calls to loop_for_commands *)
   let last_cmd = ref None in
-  let rec loop _ =
-    let cmd =
-      print_string "(3db) ";
-      try Some (parse (read_line ()))
-      with CmdParseError msg ->
-        print_endline (Printf.sprintf "command parse error: %s" msg);
-        None
+  fun (machine : stew_3000) (ins : instr) ->
+    let rec loop _ =
+      let cmd =
+        print_string prompt;
+        try Some (parse (read_line ()))
+        with CmdParseError msg ->
+          print_endline (Printf.sprintf "command parse error: %s" msg);
+          (* clear cached last command *)
+          last_cmd := None;
+          None
+      in
+      match cmd with
+      (* next instruction, break out of loop & back to emulator *)
+      | Some Next -> last_cmd := Some Next
+      (* empty input, repeat last command *)
+      | Some NoCommand -> (
+          match !last_cmd with
+          | Some Next -> ()
+          | Some cmd ->
+              exec_command cmd machine ins;
+              loop ()
+          | None -> loop ())
+      (* parsed command, run it *)
+      | Some cmd ->
+          last_cmd := Some cmd;
+          exec_command cmd machine ins;
+          loop ()
+      | None -> loop ()
     in
-    match cmd with
-    (* next instruction, break out of loop & back to emulator *)
-    | Some Next -> ()
-    (* empty input, repeat last command *)
-    | Some NoCommand -> (
-        match !last_cmd with
-        | Some cmd ->
-            exec_command cmd machine ins;
-            loop ()
-        | None -> loop ())
-    (* parsed command, run it *)
-    | Some cmd ->
-        last_cmd := Some cmd;
-        exec_command cmd machine ins;
-        loop ()
-    | None -> loop ()
-  in
-  loop ()
+    loop ()

--- a/lang/emulator/command.ml
+++ b/lang/emulator/command.ml
@@ -1,0 +1,68 @@
+open Machine
+open Asm.Isa
+
+type register = A | B | C | SP | PC
+
+type flag = ZF | SF | OF
+
+type command =
+  | PrintReg of register
+  | PrintFlag of flag
+  | PrintStackAtAddr of int
+  | PrintRegs
+  | PrintFlags
+  | PrintDecHistory
+  | PrintStack
+  | PrintFullState
+  | PrintCurrentIns
+  | SetReg of register * int
+  | SetFlag of flag * bool
+  | SetStackAtAddr of int * int
+  | SetHalted of bool
+  | Next
+
+let print_line (str : string) = Printf.printf "%s\n" str
+
+(* [exec_command] carries out the command given, updating the given machine *)
+let exec_command (cmd : command) (machine : stew_3000) (ins : instr) =
+  match cmd with
+  | PrintReg reg ->
+      print_line
+        (match reg with
+        | A -> string_of_reg "a" machine.a
+        | B -> string_of_reg "b" machine.b
+        | C -> string_of_reg "c" machine.c
+        | SP -> string_of_reg "sp" machine.sp
+        | PC -> string_of_reg "pc" machine.pc)
+  | PrintFlag flag ->
+      print_line
+        (match flag with
+        | ZF -> string_of_flag "zf" machine.zflag
+        | SF -> string_of_flag "sf" machine.sflag
+        | OF -> string_of_flag "of" machine.oflag)
+  | PrintStackAtAddr addr ->
+      print_line (string_of_stack_at_addr machine.stack addr)
+  | PrintRegs -> print_line (string_of_all_regs machine)
+  | PrintFlags -> print_line (string_of_all_flags machine)
+  | PrintDecHistory ->
+      print_line (string_of_dec_display machine.dec_disp_history)
+  | PrintStack -> print_line (string_of_stack machine.stack)
+  | PrintFullState -> print_line (string_of_stew_3000 machine)
+  | PrintCurrentIns -> print_line (string_of_instr ins)
+  | SetReg (reg, value) -> (
+      match reg with
+      | A -> machine.a <- value
+      | B -> machine.b <- value
+      | C -> machine.c <- value
+      | SP -> machine.sp <- value
+      | PC -> machine.pc <- value)
+  | SetFlag (flag, value) -> (
+      match flag with
+      | ZF -> machine.zflag <- value
+      | SF -> machine.sflag <- value
+      | OF -> machine.oflag <- value)
+  | SetStackAtAddr (addr, value) ->
+      let unsigned_addr = Numbers.as_8bit_unsigned addr in
+      Array.set machine.stack unsigned_addr value
+  | SetHalted halted -> machine.halted <- halted
+  | Next -> ()

--- a/lang/emulator/command.ml
+++ b/lang/emulator/command.ml
@@ -4,34 +4,34 @@ open Ast
 open Parser
 open Util
 
-(* 
-  Command Examples:
-  print a
-  print zf
-  print stack[17]
-  print regs
-  print flags
-  print dec
-  print stack
-  print machine
-  print ins
-  set a 0xae
-  set of 1
-  set stack[10] 0xff
-  set halted true
-  next
- *)
+(* [clear_screen] clears the screen and moves the cursor to home position *)
+let clear_screen _ = Printf.printf "\027[2J\027[H"
 
 let help_message =
-  let help_line cmd descrip = Printf.sprintf "  %17s\t%s" cmd descrip in
+  let help_line cmd descrip = Printf.sprintf "  %23s\t%s" cmd descrip in
   [
     "3db - The 3000 debugger";
     "";
-    "Basic commands:";
-    help_line "print <state>" "prints state (register, flag, stack, etc)";
-    help_line "set <state> <imm>" "sets state to an immediate";
-    help_line "next" "executes the current instruction, moving to the next";
-    help_line "help" "prints this message";
+    "Commands:";
+    help_line "print <reg>" "print register contents";
+    help_line "print <flag>" "print flag's state";
+    help_line "print stack[<addr>]" "print stack contents at address";
+    help_line "print regs" "print all register contents";
+    help_line "print flags" "print all flag info";
+    help_line "print dec" "print decimal display history";
+    help_line "print stack" "print full stack";
+    help_line "print machine" "print full machine state";
+    help_line "print ins" "print instruction about to be executed";
+    help_line "print halted" "print whether machine has halted";
+    help_line "set <reg> <imm>" "set a register's contents";
+    help_line "set <flag> <bool>" "set/unset a flag";
+    help_line "set stack[<addr>] <imm>" "set stack at address";
+    help_line "set halted <bool>" "set the machine's halted state";
+    help_line "next" "execute current instruction and move to next";
+    help_line "clear" "clears the screen";
+    help_line "help" "print this message";
+    "";
+    "Note: enter repeats the last command";
   ]
   |> String.concat "\n"
 
@@ -82,6 +82,7 @@ let exec_command (cmd : command) (machine : stew_3000) (ins : instr) =
   | SetHalted halted -> machine.halted <- halted
   | NoCommand | Next -> ()
   | Help -> print_endline help_message
+  | Clear -> clear_screen ()
 
 let prompt = Colors.log "(3db) "
 

--- a/lang/emulator/command.ml
+++ b/lang/emulator/command.ml
@@ -22,6 +22,19 @@ open Util
   next
  *)
 
+let help_message =
+  let help_line cmd descrip = Printf.sprintf "  %17s\t%s" cmd descrip in
+  [
+    "3db - The 3000 debugger";
+    "";
+    "Basic commands:";
+    help_line "print <state>" "prints state (register, flag, stack, etc)";
+    help_line "set <state> <imm>" "sets state to an immediate";
+    help_line "next" "executes the current instruction, moving to the next";
+    help_line "help" "prints this message";
+  ]
+  |> String.concat "\n"
+
 (* [exec_command] carries out the command given, updating the given machine *)
 let exec_command (cmd : command) (machine : stew_3000) (ins : instr) =
   match cmd with
@@ -68,6 +81,7 @@ let exec_command (cmd : command) (machine : stew_3000) (ins : instr) =
       Array.set machine.stack unsigned_addr value
   | SetHalted halted -> machine.halted <- halted
   | NoCommand | Next -> ()
+  | Help -> print_endline help_message
 
 let prompt = Colors.log "(3db) "
 

--- a/lang/emulator/dune
+++ b/lang/emulator/dune
@@ -1,6 +1,12 @@
+(ocamllex
+ (modules lex))
+
+(menhir
+ (modules parse))
+
 (library
   (name emulator)
-  (libraries asm util))
+  (libraries asm util core))
 
 (env
   (dev

--- a/lang/emulator/emulator.ml
+++ b/lang/emulator/emulator.ml
@@ -283,6 +283,7 @@ let emulate (pgrm : instr list) (verbosity : int) : stew_3000 =
     if machine.halted then ()
     else
       let ins = get_current_ins pgrm machine addr_to_index in
+      Command.stop_for_commands machine ins;
       Logging.log_current_ins verbosity ins;
       emulate_instr ins machine label_to_addr addr_to_index index_to_addr
         verbosity;

--- a/lang/emulator/emulator.ml
+++ b/lang/emulator/emulator.ml
@@ -29,24 +29,34 @@ let string_of_stew_3000 (machine : stew_3000) : string =
     | [] -> "(no output)"
     | _ -> List.map string_of_int history |> String.concat ", "
   in
+  let string_of_stack_value (value : int) =
+    if value = 0 then "__" else sprintf "%02x" (Numbers.as_8bit_unsigned value)
+  in
   let string_of_stack (stack : int list) : string =
     List.mapi
-      (fun i elt ->
-        if i mod 8 = 0 then sprintf "\n0x%02x:\t|%3d" i elt
-        else sprintf "%3d" elt)
+      (fun i value ->
+        if i mod 8 = 0 then
+          sprintf "\n0x%02x: %s" i (string_of_stack_value value)
+        else string_of_stack_value value)
       stack
-    |> String.concat "|"
+    |> String.concat " "
   in
-
+  (* [string_of_reg] formats a register's contents in a string,
+     showing unsigned hex, and unsigned/signed decimal *)
+  let string_of_reg (name : string) (contents : int) =
+    let unsigned = Numbers.as_8bit_unsigned contents in
+    let signed = Numbers.as_8bit_signed contents in
+    sprintf "%2s: 0x%02x %4d %4d" name unsigned unsigned signed
+  in
   let bool_to_int (b : bool) = if b then 1 else 0 in
   sprintf
-    "Emulated Stew 3000 State:\n\
-     == Registers ==\n\
-     a: %d\n\
-     b: %d\n\
-     c: %d\n\
-     sp: %d\n\
-     pc: %d\n\n\
+    "== Registers ==\n\
+     %s\n\
+     %s\n\
+     %s\n\
+     %s\n\
+     %s\n\
+     %s\n\n\
      == Flags ==\n\
      zf: %d\n\
      sf: %d\n\
@@ -55,7 +65,12 @@ let string_of_stew_3000 (machine : stew_3000) : string =
      == Decimal Display History == (most recent last)\n\
      %s\n\n\
      == Stack ==%s\n"
-    machine.a machine.b machine.c machine.sp machine.pc
+    "     hex  uns  sig"
+    (string_of_reg "a" machine.a)
+    (string_of_reg "b" machine.b)
+    (string_of_reg "c" machine.c)
+    (string_of_reg "sp" machine.sp)
+    (string_of_reg "pc" machine.pc)
     (bool_to_int machine.zflag)
     (bool_to_int machine.sflag)
     (bool_to_int machine.oflag)

--- a/lang/emulator/emulator.ml
+++ b/lang/emulator/emulator.ml
@@ -5,96 +5,7 @@ open Util.Num_env
 open Util.Srcloc
 open Util
 open Asm
-
-(*  stew_3000 models the programmer-visible state of the machine
-    NOTE: dec_disp_history is a record of every byte that has 
-    been sent to the decimal display so far *)
-type stew_3000 = {
-  mutable a : int;
-  mutable b : int;
-  mutable c : int;
-  mutable sp : int;
-  mutable zflag : bool;
-  mutable sflag : bool;
-  mutable oflag : bool;
-  mutable stack : int array;
-  mutable dec_disp_history : int list;
-  mutable pc : int;
-  mutable halted : bool;
-}
-
-let string_of_stew_3000 (machine : stew_3000) : string =
-  let string_of_dec_display (history : int list) =
-    match history with
-    | [] -> "(no output)"
-    | _ -> List.map string_of_int history |> String.concat ", "
-  in
-  let string_of_stack_value (value : int) =
-    if value = 0 then "__" else sprintf "%02x" (Numbers.as_8bit_unsigned value)
-  in
-  let string_of_stack (stack : int list) : string =
-    List.mapi
-      (fun i value ->
-        if i mod 8 = 0 then
-          sprintf "\n0x%02x: %s" i (string_of_stack_value value)
-        else string_of_stack_value value)
-      stack
-    |> String.concat " "
-  in
-  (* [string_of_reg] formats a register's contents in a string,
-     showing unsigned hex, and unsigned/signed decimal *)
-  let string_of_reg (name : string) (contents : int) =
-    let unsigned = Numbers.as_8bit_unsigned contents in
-    let signed = Numbers.as_8bit_signed contents in
-    sprintf "%2s: 0x%02x %4d %4d" name unsigned unsigned signed
-  in
-  let bool_to_int (b : bool) = if b then 1 else 0 in
-  sprintf
-    "== Registers ==\n\
-     %s\n\
-     %s\n\
-     %s\n\
-     %s\n\
-     %s\n\
-     %s\n\n\
-     == Flags ==\n\
-     zf: %d\n\
-     sf: %d\n\
-     of: %d\n\n\
-     halted? %s\n\n\
-     == Decimal Display History == (most recent last)\n\
-     %s\n\n\
-     == Stack ==%s\n"
-    "     hex  uns  sig"
-    (string_of_reg "a" machine.a)
-    (string_of_reg "b" machine.b)
-    (string_of_reg "c" machine.c)
-    (string_of_reg "sp" machine.sp)
-    (string_of_reg "pc" machine.pc)
-    (bool_to_int machine.zflag)
-    (bool_to_int machine.sflag)
-    (bool_to_int machine.oflag)
-    (if machine.halted then "yes" else "no")
-    (string_of_dec_display machine.dec_disp_history)
-    (string_of_stack (Array.to_list machine.stack))
-
-let stack_size = 256
-
-(* [new_stew_3000] constructs a new machine state in initial state *)
-let new_stew_3000 _ : stew_3000 =
-  {
-    a = 0;
-    b = 0;
-    c = 0;
-    sp = 0;
-    zflag = false;
-    sflag = false;
-    oflag = false;
-    stack = Array.make stack_size 0;
-    dec_disp_history = [];
-    pc = 0;
-    halted = false;
-  }
+open Machine
 
 type emu_err =
   | InvalidProgramCounter of stew_3000
@@ -322,9 +233,7 @@ let emulate_instr (ins : instr) (machine : stew_3000) (label_to_addr : int env)
       let src_value = load_reg src in
       machine.dec_disp_history <-
         insert_at_end machine.dec_disp_history src_value;
-      (* at verbosity level 1, out instrs print their output *)
-      if verbosity >= 1 then printf "%s %d\n" (Colors.log "[output]") src_value
-      else ();
+      Logging.log_output verbosity src_value;
       inc_pc ()
   | Label _ | Nop _ -> inc_pc ()
   (* XXX: Dic and Did not currently supported *)
@@ -374,20 +283,10 @@ let emulate (pgrm : instr list) (verbosity : int) : stew_3000 =
     if machine.halted then ()
     else
       let ins = get_current_ins pgrm machine addr_to_index in
-      (* verbosity level 2, current instruction is logged *)
-      if verbosity >= 2 then
-        printf "%s %s\n"
-          (Colors.log "[current instruction]")
-          (string_of_instr ins)
-      else ();
+      Logging.log_current_ins verbosity ins;
       emulate_instr ins machine label_to_addr addr_to_index index_to_addr
         verbosity;
-      (* verbosity level 3, entire machine state is logged *)
-      if verbosity >= 3 then
-        printf "%s\n%s"
-          (Colors.log "[state after executing]")
-          (string_of_stew_3000 machine)
-      else ();
+      Logging.log_full_state verbosity machine;
       run ()
   in
   run ();

--- a/lang/emulator/lex.mll
+++ b/lang/emulator/lex.mll
@@ -1,0 +1,66 @@
+{
+  open Parse
+  exception Error of string
+}
+
+rule token = parse
+| [' ' '\t']+
+  { token lexbuf }
+| '-'?['0'-'9']+ as i
+  { NUM (int_of_string i) }
+| '-'?"0x"['0'-'9''a'-'f''A'-'F']+ as hex
+  { NUM (int_of_string hex) }
+| '-'?"0b"['0' '1']+ as binary
+  { NUM (int_of_string binary) }
+| "true"
+  { BOOL true }
+| "false"
+  { BOOL false }
+| "a" 
+  { REG A }
+| "b"
+  { REG B }
+| "c"
+  { REG C }
+| "sp"
+  { REG SP }
+| "pc"
+  { REG PC }
+| "zf"
+  { FLAG ZF }
+| "sf"
+  { FLAG SF }
+| "of"
+  { FLAG OF }
+| "stack" 
+  { STACK }
+| '['
+  { LBRACKET }
+| ']'
+  { RBRACKET }
+| "regs"
+  { REGS }
+| "flags"
+  { FLAGS }
+| "machine"
+  { MACHINE }
+| "dec"
+  { DEC }
+| "ins"
+  { INS }
+| "halted"
+  { HALTED }
+| "print"
+  { PRINT }
+| "set"
+  { SET }
+| "next"
+  { NEXT }
+| eof
+    { EOF }
+| _
+    { raise (Error 
+      (Printf.sprintf 
+        "unexpected character '%s' at position %d" 
+        (String.escaped (Lexing.lexeme lexbuf))
+        (Lexing.lexeme_start lexbuf))) }

--- a/lang/emulator/lex.mll
+++ b/lang/emulator/lex.mll
@@ -52,9 +52,13 @@ rule token = parse
   { HALTED }
 | "print"
   { PRINT }
+| "p"
+  { PRINT }
 | "set"
   { SET }
 | "next"
+  { NEXT }
+| "n"
   { NEXT }
 | eof
     { EOF }

--- a/lang/emulator/lex.mll
+++ b/lang/emulator/lex.mll
@@ -60,6 +60,8 @@ rule token = parse
   { NEXT }
 | "n"
   { NEXT }
+| "help"
+  { HELP }
 | eof
     { EOF }
 | _

--- a/lang/emulator/lex.mll
+++ b/lang/emulator/lex.mll
@@ -62,6 +62,8 @@ rule token = parse
   { NEXT }
 | "help"
   { HELP }
+| "clear"
+  { CLEAR }
 | eof
     { EOF }
 | _

--- a/lang/emulator/logging.ml
+++ b/lang/emulator/logging.ml
@@ -12,16 +12,9 @@ let log_output (verbosity : int) (out_value : int) =
 
 (* [log_current_ins] logs the current instruction as it is about
   to be executed, if verbosity is at level 2 or greater *)
-let log_current_ins (verbosity : int) (ins : instr) =
+let log_current_ins (verbosity : int) (machine : stew_3000) (ins : instr) =
   if verbosity >= 2 then
-    printf "%s %s\n" (Colors.log "[current instruction]") (string_of_instr ins)
-  else ()
-
-(* [log_full_state] logs the entire state of the machine after
-  executing an instruction, if verbosity is at level 3 or greater. *)
-let log_full_state (verbosity : int) (machine : stew_3000) =
-  if verbosity >= 3 then
-    printf "%s\n%s"
-      (Colors.log "[state after executing]")
-      (string_of_stew_3000 machine)
+    printf "%s %s\n"
+      (Colors.log (sprintf "[executing at 0x%02x]" machine.pc))
+      (string_of_instr ins)
   else ()

--- a/lang/emulator/logging.ml
+++ b/lang/emulator/logging.ml
@@ -18,3 +18,13 @@ let log_current_ins (verbosity : int) (machine : stew_3000) (ins : instr) =
       (Colors.log (sprintf "[executing at 0x%02x]" machine.pc))
       (string_of_instr ins)
   else ()
+
+(* [warn_arith_overflow] prints a warning (if enabled) indicating
+  that signed overflow occurred during an arithmetic instruction *)
+let warn_arith_overflow (warn : bool) (ins : instr) (result : int) (pc : int) =
+  if warn then
+    print_endline
+      (Colors.warn
+         (sprintf "[arithmetic overflow at pc 0x%02x %s: produced %d]" pc
+            (string_of_instr ins) result))
+  else ()

--- a/lang/emulator/logging.ml
+++ b/lang/emulator/logging.ml
@@ -1,0 +1,27 @@
+open Util
+open Printf
+open Asm.Isa
+open Machine
+
+(* [log_output] logs the bytes sent to the decimal display  
+  via out instructions as they are emulated, if verbosity is 
+  at level 1 or greater. *)
+let log_output (verbosity : int) (out_value : int) =
+  if verbosity >= 1 then printf "%s %d\n" (Colors.log "[output]") out_value
+  else ()
+
+(* [log_current_ins] logs the current instruction as it is about
+  to be executed, if verbosity is at level 2 or greater *)
+let log_current_ins (verbosity : int) (ins : instr) =
+  if verbosity >= 2 then
+    printf "%s %s\n" (Colors.log "[current instruction]") (string_of_instr ins)
+  else ()
+
+(* [log_full_state] logs the entire state of the machine after
+  executing an instruction, if verbosity is at level 3 or greater. *)
+let log_full_state (verbosity : int) (machine : stew_3000) =
+  if verbosity >= 3 then
+    printf "%s\n%s"
+      (Colors.log "[state after executing]")
+      (string_of_stew_3000 machine)
+  else ()

--- a/lang/emulator/machine.ml
+++ b/lang/emulator/machine.ml
@@ -17,60 +17,92 @@ type stew_3000 = {
   mutable halted : bool;
 }
 
-let string_of_stew_3000 (machine : stew_3000) : string =
-  let string_of_dec_display (history : int list) =
-    match history with
-    | [] -> "(no output)"
-    | _ -> List.map string_of_int history |> String.concat ", "
-  in
+(* [num_as_hex_uns_sig] produces a string containing the given
+  number printed as unsigned hex, unsigned decimal, and signed decimal *)
+let num_as_hex_uns_sig (num : int) =
+  let unsigned = Numbers.as_8bit_unsigned num in
+  let signed = Numbers.as_8bit_signed num in
+  sprintf "0x%02x %4d %4d" unsigned unsigned signed
+
+let reg_header = "     hex  uns  sig"
+
+(* [string_of_reg] formats a register's contents in a string,
+   showing unsigned hex, and unsigned/signed decimal *)
+let string_of_reg (name : string) (contents : int) =
+  sprintf "%2s: %s" name (num_as_hex_uns_sig contents)
+
+(* [string_of_all_regs] formats all registers for printing *)
+let string_of_all_regs (machine : stew_3000) =
+  [
+    reg_header;
+    string_of_reg "a" machine.a;
+    string_of_reg "b" machine.b;
+    string_of_reg "c" machine.c;
+    string_of_reg "sp" machine.sp;
+    string_of_reg "pc" machine.pc;
+  ]
+  |> String.concat "\n"
+
+(* [string_of_flag] formats a flag's value in a string *)
+let string_of_flag (name : string) (contents : bool) =
+  let bool_to_int (b : bool) = if b then 1 else 0 in
+  sprintf "%s: %d" name (bool_to_int contents)
+
+(* [string_of_all_flags] formats all a machine's flags for printing *)
+let string_of_all_flags (machine : stew_3000) =
+  [
+    string_of_flag "zf" machine.zflag;
+    string_of_flag "sf" machine.sflag;
+    string_of_flag "of" machine.oflag;
+  ]
+  |> String.concat "\n"
+
+(* [string_of_halted] produces "yes" if halted is true and "no" otherwise *)
+let string_of_halted (halted : bool) : string = if halted then "yes" else "no"
+
+(* [string_of_dec_display] produces a string of the decimal display history *)
+let string_of_dec_display (history : int list) =
+  match history with
+  | [] -> "(no output)"
+  | _ -> List.map string_of_int history |> String.concat ", "
+
+(* [string_of_stack_at_addr] gets a string of the stack contents 
+  at a given address. The address is always interpreted as unsigned 8-bit *)
+let string_of_stack_at_addr (stack : int array) (addr : int) =
+  let stack = Array.to_list stack in
+  let addr_as_unsigned = Numbers.as_8bit_unsigned addr in
+  let contents = List.nth stack addr_as_unsigned in
+  sprintf "stack[%d] = %s" addr_as_unsigned (num_as_hex_uns_sig contents)
+
+(* [string_of_stack] constructs a string containing the entire contents of
+  the stack *)
+let string_of_stack (stack : int array) : string =
+  let stack = Array.to_list stack in
   let string_of_stack_value (value : int) =
     if value = 0 then "__" else sprintf "%02x" (Numbers.as_8bit_unsigned value)
   in
-  let string_of_stack (stack : int list) : string =
-    List.mapi
-      (fun i value ->
-        if i mod 8 = 0 then
-          sprintf "\n0x%02x: %s" i (string_of_stack_value value)
-        else string_of_stack_value value)
-      stack
-    |> String.concat " "
-  in
-  (* [string_of_reg] formats a register's contents in a string,
-     showing unsigned hex, and unsigned/signed decimal *)
-  let string_of_reg (name : string) (contents : int) =
-    let unsigned = Numbers.as_8bit_unsigned contents in
-    let signed = Numbers.as_8bit_signed contents in
-    sprintf "%2s: 0x%02x %4d %4d" name unsigned unsigned signed
-  in
-  let bool_to_int (b : bool) = if b then 1 else 0 in
+  List.mapi
+    (fun i value ->
+      if i mod 8 = 0 then sprintf "\n0x%02x: %s" i (string_of_stack_value value)
+      else string_of_stack_value value)
+    stack
+  |> String.concat " "
+
+let string_of_stew_3000 (machine : stew_3000) : string =
   sprintf
     "== Registers ==\n\
-     %s\n\
-     %s\n\
-     %s\n\
-     %s\n\
-     %s\n\
      %s\n\n\
      == Flags ==\n\
-     zf: %d\n\
-     sf: %d\n\
-     of: %d\n\n\
+     %s\n\n\
      halted? %s\n\n\
      == Decimal Display History == (most recent last)\n\
      %s\n\n\
      == Stack ==%s\n"
-    "     hex  uns  sig"
-    (string_of_reg "a" machine.a)
-    (string_of_reg "b" machine.b)
-    (string_of_reg "c" machine.c)
-    (string_of_reg "sp" machine.sp)
-    (string_of_reg "pc" machine.pc)
-    (bool_to_int machine.zflag)
-    (bool_to_int machine.sflag)
-    (bool_to_int machine.oflag)
-    (if machine.halted then "yes" else "no")
+    (string_of_all_regs machine)
+    (string_of_all_flags machine)
+    (string_of_halted machine.halted)
     (string_of_dec_display machine.dec_disp_history)
-    (string_of_stack (Array.to_list machine.stack))
+    (string_of_stack machine.stack)
 
 let stack_size = 256
 

--- a/lang/emulator/machine.ml
+++ b/lang/emulator/machine.ml
@@ -1,0 +1,91 @@
+open Printf
+
+(*  stew_3000 models the programmer-visible state of the machine
+    NOTE: dec_disp_history is a record of every byte that has 
+    been sent to the decimal display so far *)
+type stew_3000 = {
+  mutable a : int;
+  mutable b : int;
+  mutable c : int;
+  mutable sp : int;
+  mutable zflag : bool;
+  mutable sflag : bool;
+  mutable oflag : bool;
+  mutable stack : int array;
+  mutable dec_disp_history : int list;
+  mutable pc : int;
+  mutable halted : bool;
+}
+
+let string_of_stew_3000 (machine : stew_3000) : string =
+  let string_of_dec_display (history : int list) =
+    match history with
+    | [] -> "(no output)"
+    | _ -> List.map string_of_int history |> String.concat ", "
+  in
+  let string_of_stack_value (value : int) =
+    if value = 0 then "__" else sprintf "%02x" (Numbers.as_8bit_unsigned value)
+  in
+  let string_of_stack (stack : int list) : string =
+    List.mapi
+      (fun i value ->
+        if i mod 8 = 0 then
+          sprintf "\n0x%02x: %s" i (string_of_stack_value value)
+        else string_of_stack_value value)
+      stack
+    |> String.concat " "
+  in
+  (* [string_of_reg] formats a register's contents in a string,
+     showing unsigned hex, and unsigned/signed decimal *)
+  let string_of_reg (name : string) (contents : int) =
+    let unsigned = Numbers.as_8bit_unsigned contents in
+    let signed = Numbers.as_8bit_signed contents in
+    sprintf "%2s: 0x%02x %4d %4d" name unsigned unsigned signed
+  in
+  let bool_to_int (b : bool) = if b then 1 else 0 in
+  sprintf
+    "== Registers ==\n\
+     %s\n\
+     %s\n\
+     %s\n\
+     %s\n\
+     %s\n\
+     %s\n\n\
+     == Flags ==\n\
+     zf: %d\n\
+     sf: %d\n\
+     of: %d\n\n\
+     halted? %s\n\n\
+     == Decimal Display History == (most recent last)\n\
+     %s\n\n\
+     == Stack ==%s\n"
+    "     hex  uns  sig"
+    (string_of_reg "a" machine.a)
+    (string_of_reg "b" machine.b)
+    (string_of_reg "c" machine.c)
+    (string_of_reg "sp" machine.sp)
+    (string_of_reg "pc" machine.pc)
+    (bool_to_int machine.zflag)
+    (bool_to_int machine.sflag)
+    (bool_to_int machine.oflag)
+    (if machine.halted then "yes" else "no")
+    (string_of_dec_display machine.dec_disp_history)
+    (string_of_stack (Array.to_list machine.stack))
+
+let stack_size = 256
+
+(* [new_stew_3000] constructs a new machine state in initial state *)
+let new_stew_3000 _ : stew_3000 =
+  {
+    a = 0;
+    b = 0;
+    c = 0;
+    sp = 0;
+    zflag = false;
+    sflag = false;
+    oflag = false;
+    stack = Array.make stack_size 0;
+    dec_disp_history = [];
+    pc = 0;
+    halted = false;
+  }

--- a/lang/emulator/numbers.ml
+++ b/lang/emulator/numbers.ml
@@ -1,0 +1,15 @@
+(* [as_8bit_unsigned] interprets an integer as an 8-bit,
+  unsigned integer *)
+let as_8bit_unsigned : int -> int =
+  let bytes = Bytes.make 1 '0' in
+  fun (n : int) ->
+    Bytes.set_uint8 bytes 0 n;
+    Bytes.get_uint8 bytes 0
+
+(* [as_8bit_signed] interprets an integer as an 8-bit,
+  signed (two's complement) integer *)
+let as_8bit_signed : int -> int =
+  let bytes = Bytes.make 1 '0' in
+  fun (n : int) ->
+    Bytes.set_int8 bytes 0 n;
+    Bytes.get_int8 bytes 0

--- a/lang/emulator/numbers.ml
+++ b/lang/emulator/numbers.ml
@@ -1,15 +1,11 @@
+(* How much to shift left in order to erase all bits 
+  other than the rightmost eight *)
+let shift_amount = Sys.int_size - 8
+
 (* [as_8bit_unsigned] interprets an integer as an 8-bit,
   unsigned integer *)
-let as_8bit_unsigned : int -> int =
-  let bytes = Bytes.make 1 '0' in
-  fun (n : int) ->
-    Bytes.set_uint8 bytes 0 n;
-    Bytes.get_uint8 bytes 0
+let as_8bit_unsigned (n : int) : int = (n lsl shift_amount) lsr shift_amount
 
 (* [as_8bit_signed] interprets an integer as an 8-bit,
   signed (two's complement) integer *)
-let as_8bit_signed : int -> int =
-  let bytes = Bytes.make 1 '0' in
-  fun (n : int) ->
-    Bytes.set_int8 bytes 0 n;
-    Bytes.get_int8 bytes 0
+let as_8bit_signed (n : int) : int = (n lsl shift_amount) asr shift_amount

--- a/lang/emulator/parse.mly
+++ b/lang/emulator/parse.mly
@@ -19,6 +19,7 @@
 %token SET
 %token NEXT
 %token HELP
+%token CLEAR
 
 %token EOF
 
@@ -71,3 +72,4 @@ set_cmd:
 other:
   | NEXT { Next }
   | HELP { Help }
+  | CLEAR { Clear }

--- a/lang/emulator/parse.mly
+++ b/lang/emulator/parse.mly
@@ -18,6 +18,7 @@
 %token PRINT
 %token SET
 %token NEXT
+%token HELP
 
 %token EOF
 
@@ -30,8 +31,8 @@ main:
   { p }
 | s = set_cmd EOF
   { s }
-| n = next EOF
-  { n }
+| o = other EOF
+  { o }
 | EOF
   { NoCommand }
 
@@ -67,5 +68,6 @@ set_cmd:
 | SET HALTED b = BOOL
   { SetHalted b }
 
-next:
+other:
   | NEXT { Next }
+  | HELP { Help }

--- a/lang/emulator/parse.mly
+++ b/lang/emulator/parse.mly
@@ -54,6 +54,8 @@ print_cmd:
   { PrintFullState }
 | PRINT INS
   { PrintCurrentIns }
+| PRINT HALTED
+  { PrintHalted }
 
 set_cmd:
 | SET r = REG v = NUM

--- a/lang/emulator/parse.mly
+++ b/lang/emulator/parse.mly
@@ -1,0 +1,69 @@
+%{ 
+  open Ast
+%}
+
+%token <int> NUM
+%token <bool> BOOL
+%token <Ast.register> REG
+%token <Ast.flag> FLAG
+%token LBRACKET
+%token RBRACKET
+%token STACK
+%token REGS
+%token FLAGS
+%token MACHINE
+%token DEC
+%token INS
+%token HALTED
+%token PRINT
+%token SET
+%token NEXT
+
+%token EOF
+
+%start <command> main
+
+%%
+
+main:
+| p = print_cmd EOF
+  { p }
+| s = set_cmd EOF
+  { s }
+| n = next EOF
+  { n }
+| EOF
+  { NoCommand }
+
+print_cmd:
+| PRINT r = REG
+  { PrintReg r }
+| PRINT f = FLAG
+  { PrintFlag f }
+| PRINT STACK LBRACKET addr = NUM RBRACKET
+  { PrintStackAtAddr addr }
+| PRINT REGS
+  { PrintRegs }
+| PRINT FLAGS
+  { PrintFlags }
+| PRINT DEC
+  { PrintDecHistory }
+| PRINT STACK
+  { PrintStack }
+| PRINT MACHINE
+  { PrintFullState }
+| PRINT INS
+  { PrintCurrentIns }
+
+set_cmd:
+| SET r = REG v = NUM
+  { SetReg (r, v) }
+| SET f = FLAG b = BOOL
+  { SetFlag (f, b) }
+| SET STACK LBRACKET addr = NUM RBRACKET v = NUM
+  { SetStackAtAddr (addr, v) }
+| SET HALTED b = BOOL
+  { SetHalted b }
+
+next:
+  | NEXT { Next }

--- a/lang/emulator/parser.ml
+++ b/lang/emulator/parser.ml
@@ -1,0 +1,18 @@
+open Ast
+
+exception CmdParseError of string
+
+(* [parse] consumes a string command and parses it into command ast *)
+let parse (s : string) : command =
+  let buf = Lexing.from_string s in
+  match Parse.main Lex.token buf with
+  | cmd -> cmd
+  | exception Lex.Error msg -> raise (CmdParseError msg)
+  | exception Parse.Error ->
+      let pos = Lexing.lexeme_start_p buf in
+      let msg =
+        Printf.sprintf "bad token '%s' at character %d"
+          (String.escaped (Lexing.lexeme buf))
+          pos.pos_bol
+      in
+      raise (CmdParseError msg)

--- a/lang/test/test_compiler.ml
+++ b/lang/test/test_compiler.ml
@@ -12,7 +12,7 @@ let main_from_body (body : stmt list) : func_defn =
 
 let compile_and_run (pgrm : prog) : stew_3000 =
   let instrs = compile pgrm in
-  emulate instrs 0 false
+  emulate instrs
 
 let test_simple_pgrm _ =
   let machine =

--- a/lang/test/test_compiler.ml
+++ b/lang/test/test_compiler.ml
@@ -12,7 +12,7 @@ let main_from_body (body : stmt list) : func_defn =
 
 let compile_and_run (pgrm : prog) : stew_3000 =
   let instrs = compile pgrm in
-  emulate instrs 0
+  emulate instrs 0 false
 
 let test_simple_pgrm _ =
   let machine =

--- a/lang/test/test_compiler.ml
+++ b/lang/test/test_compiler.ml
@@ -2,6 +2,7 @@ open OUnit2
 open Compiler.Compile
 open Compiler.Ast
 open Emulator
+open Emulator__Machine
 open Util.Srcloc
 
 let dummy_src_loc = loc 0 0

--- a/lang/test/test_emulator.ml
+++ b/lang/test/test_emulator.ml
@@ -1,6 +1,7 @@
 open OUnit2
 open Asm.Isa
 open Emulator
+open Asm.Assemble
 
 (* wrapper around emulate, with no logging *)
 let run_emulator (pgrm : instr list) = emulate pgrm 0
@@ -204,44 +205,44 @@ let test_call_ret _ =
 
 let test_dup_label _ =
   assert_raises
-    (EmulatorError (DuplicateLabel "dup", None))
+    (AssembleError (DuplicateLabel "dup", None))
     (fun _ ->
       run_emulator
         [ Label ("dup", None); Label ("dup", None); Label ("dup", None) ])
 
-let test_invalid_pc _ =
+let test_invalid_pc_increment _ =
   let machine = new_stew_3000 () in
-  (* pc runs right off the end *)
-  machine.pc <- 3;
+  (* pc runs right off the end, can't increment from 0x2 to 0x3 *)
+  machine.pc <- 2;
   assert_raises
-    (EmulatorError (InvalidProgramCounter machine, None))
+    (EmulatorError (InvalidPCIncrement machine, None))
     (fun _ -> run_emulator [ Nop None; Nop None; Nop None ])
 
 let test_invalid_target _ =
   assert_raises
-    (EmulatorError (InvalidTarget "not_here", None))
+    (AssembleError (InvalidTarget "not_here", None))
     (fun _ -> run_emulator [ Jmp ("not_here", None) ]);
   assert_raises
-    (EmulatorError (InvalidTarget "not_a_fun", None))
+    (AssembleError (InvalidTarget "not_a_fun", None))
     (fun _ -> run_emulator [ Call ("not_a_fun", None) ])
 
 let test_invalid_imm _ =
   assert_raises
-    (EmulatorError (InvalidImm (-129), None))
+    (AssembleError (InvalidImm (-129), None))
     (fun _ -> run_emulator [ Addi (-129, B, None) ]);
   assert_raises
-    (EmulatorError (InvalidImm (-129), None))
+    (AssembleError (InvalidImm (-129), None))
     (fun _ -> run_emulator [ Lds (-129, A, None) ]);
   assert_raises
-    (EmulatorError (InvalidImm 256, None))
+    (AssembleError (InvalidImm 256, None))
     (fun _ -> run_emulator [ Sts (C, 256, None) ])
 
 let test_invalid_instr _ =
   assert_raises
-    (EmulatorError (InvalidInstr (Sub (B, B, None)), None))
+    (AssembleError (InvalidInstr (Sub (B, B, None)), None))
     (fun _ -> run_emulator [ Sub (B, B, None) ]);
   assert_raises
-    (EmulatorError (InvalidInstr (Cmpi (Imm 1, Imm 2, None)), None))
+    (AssembleError (InvalidInstr (Cmpi (Imm 1, Imm 2, None)), None))
     (fun _ -> run_emulator [ Cmpi (Imm 1, Imm 2, None) ])
 
 let test_overflow_immediates _ =
@@ -283,7 +284,7 @@ let suite =
          "test_sign_flag" >:: test_sign_flag;
          "test_overflow_flag" >:: test_overflow_flag;
          "test_call_ret" >:: test_call_ret;
-         "test_invalid_pc" >:: test_invalid_pc;
+         "test_invalid_pc_increment" >:: test_invalid_pc_increment;
          "test_invalid_target" >:: test_invalid_target;
          "test_invalid_imm" >:: test_invalid_imm;
          "test_invalid_instr" >:: test_invalid_instr;

--- a/lang/test/test_emulator.ml
+++ b/lang/test/test_emulator.ml
@@ -1,6 +1,7 @@
 open OUnit2
 open Asm.Isa
 open Emulator
+open Emulator__Machine
 open Asm.Assemble
 
 (* wrapper around emulate, with no logging *)

--- a/lang/test/test_emulator.ml
+++ b/lang/test/test_emulator.ml
@@ -5,7 +5,7 @@ open Emulator__Machine
 open Asm.Assemble
 
 (* wrapper around emulate, with no logging *)
-let run_emulator (pgrm : instr list) = emulate pgrm 0
+let run_emulator (pgrm : instr list) = emulate pgrm 0 false
 
 let assert_int_eq (exp : int) (act : int) =
   assert_equal exp act ~printer:string_of_int

--- a/lang/test/test_emulator.ml
+++ b/lang/test/test_emulator.ml
@@ -171,7 +171,7 @@ let test_overflow_flag _ =
   let machine =
     run_emulator [ Mvi (-128, B, None); Subi (1, B, None); Hlt None ]
   in
-  assert_bool "overflow flag set after -128 - 1" machine.oflag;
+  assert_bool "overflow flag set after cmp -128 - 1" machine.oflag;
   let machine =
     run_emulator
       [ Mvi (-120, A, None); Mvi (100, B, None); Cmp (A, B, None); Hlt None ]

--- a/lang/test/test_emulator.ml
+++ b/lang/test/test_emulator.ml
@@ -5,7 +5,7 @@ open Emulator__Machine
 open Asm.Assemble
 
 (* wrapper around emulate, with no logging *)
-let run_emulator (pgrm : instr list) = emulate pgrm 0 false
+let run_emulator (pgrm : instr list) = emulate pgrm
 
 let assert_int_eq (exp : int) (act : int) =
   assert_equal exp act ~printer:string_of_int

--- a/lang/util/colors.ml
+++ b/lang/util/colors.ml
@@ -20,8 +20,12 @@ let br_black s = effect "90" s
 
 let white s = effect "37" s
 
+let magenta s = effect "35" s
+
 let error s = bold (br_red s)
 
 let success s = bold (br_green s)
 
 let log s = bold (br_blue s)
+
+let warn s = bold (magenta s)

--- a/lang/util/num_env.ml
+++ b/lang/util/num_env.ml
@@ -1,0 +1,11 @@
+module NumEnv = Map.Make (struct
+  type t = int
+
+  let compare = compare
+end)
+
+type 'a num_env = 'a NumEnv.t
+
+include NumEnv
+
+let of_list l = l |> List.to_seq |> of_seq

--- a/programs/diagnostics/call.3000.s
+++ b/programs/diagnostics/call.3000.s
@@ -1,7 +1,3 @@
-;; !!! NOTE: this fails on the emulator which uses
-;; indices into a list of instructions as "addresses",
-;; but should succeed on actual hardware. 
-
 entry:
   call l1
   jmp assert_not_reached

--- a/programs/diagnostics/ret.3000.s
+++ b/programs/diagnostics/ret.3000.s
@@ -1,7 +1,3 @@
-;; !!! NOTE: this doesn't necessarily work on the emulator
-;; indices into a list of instructions as "addresses",
-;; but should succeed on actual hardware.
-
 entry:
   ; fake a return address at the l1 label
   mvi 0x07, a

--- a/programs/fib.3000.s
+++ b/programs/fib.3000.s
@@ -4,8 +4,8 @@ entry:
 
 loop:
     add b, a
-    cmpi a, 127
-    jg stop
+    cmpi a, 0
+    jl stop
     out a
     mov a, c
     mov b, a

--- a/programs/stack.3000.s
+++ b/programs/stack.3000.s
@@ -1,0 +1,7 @@
+; fills up the stack by setting stack[i] = i
+loop:
+	st a, a
+	inr a
+	cmpi a, 0
+	jne loop
+	hlt


### PR DESCRIPTION
Completely redid the emulator.

- **Better 8-bit numbers:** emulation of signed/unsigned 8-bit arithmetic is actually correct now, flags are set in the right places because the emulator is approximating the hardware much closer now.
- **Use physical addresses where possible:** the emulator actually uses physical addresses for things like the program counter / return addresses. This means it passes some of the diagnostics that it failed to emulate before.
- **Use the assembler instead of replicating functionality:** the emulator now invokes the assembler on the input as its first step. This provides rich info about the resulting binary (giving the emulator access to physical addresses, for instance), and also performs validation since the assembler validates the program.
- **More useful logging:** machine values are now logged as unsigned hex / unsigned decimal / signed decimal, so as not to impose an interpretation on them. See example image below.

     ![registers](https://user-images.githubusercontent.com/13399527/119916436-870d5500-bf32-11eb-88b0-090de540e076.png)

- **Interactive debug-mode:** added a flag that runs the program in `3db` (3000 debugger) mode. This allows stepping through execution and inspecting/updating the full machine state as you go. See the supported commands below:

    ![commands](https://user-images.githubusercontent.com/13399527/119916701-08fd7e00-bf33-11eb-9476-bf640fbdb137.png)

- **Warnings**: right now there is only a warning for if signed overflow occurs during an arithmetic instruction, but we could add more in the future.

I have yet to do this but we should eventually go through the diagnostics and make sure they all pass the emulator to make sure they aren't faulty. I did note however that the emulator now passes both the `call` and `ret` diagnostics that the previous version did not.
