### PR TITLE
parser for source language

### DIFF
--- a/TODO
+++ b/TODO
@@ -16,7 +16,10 @@ Assembler
 
 Compiler
   [x] decide on language constructs
-  [] parser 
+  [] parser
+  [] runtime
+    [] add assert to runtime
+    [] test runtime
   [] implement compiler
   [] type checking
     NOTE: 

--- a/TODO
+++ b/TODO
@@ -16,7 +16,7 @@ Assembler
 
 Compiler
   [x] decide on language constructs
-  [] parser
+  [x] parser
   [] runtime
     [] add assert to runtime
     [] test runtime

--- a/lang/compiler/dune
+++ b/lang/compiler/dune
@@ -1,3 +1,9 @@
+(ocamllex
+ (modules lex))
+
+(menhir
+ (modules parse))
+
 (library
   (name compiler)
   (libraries util asm core))

--- a/lang/compiler/lex.mll
+++ b/lang/compiler/lex.mll
@@ -28,6 +28,8 @@ rule token = parse
   { RBRACE (loc_from_lexbuf lexbuf) }
 | ';'
   { SEMICOLON (loc_from_lexbuf lexbuf) }
+| ','
+  { COMMA (loc_from_lexbuf lexbuf) }
 | '+'
   { PLUS (loc_from_lexbuf lexbuf) }
 | '-'

--- a/lang/compiler/lex.mll
+++ b/lang/compiler/lex.mll
@@ -1,0 +1,100 @@
+{
+  open Parse
+  open Util.Srcloc
+  exception Error of string * src_loc
+}
+
+rule token = parse
+| [' ' '\t']+
+  { token lexbuf }
+| "//"[^'\n']*?
+  { token lexbuf }
+| "/*"_*?"*/"
+  { token lexbuf }
+| '\n' { Lexing.new_line lexbuf; token lexbuf }
+| '-'?['0'-'9']+ as i
+  { NUM (int_of_string i, loc_from_lexbuf lexbuf) }
+| '-'?"0x"['0'-'9''a'-'f''A'-'F']+ as hex
+  { NUM (int_of_string hex, loc_from_lexbuf lexbuf) }
+| '-'?"0b"['0' '1']+ as binary
+  { NUM (int_of_string binary, loc_from_lexbuf lexbuf) }
+| '('
+  { LPAREN (loc_from_lexbuf lexbuf) }
+| ')'
+  { RPAREN (loc_from_lexbuf lexbuf) }
+| '{'
+  { LBRACE (loc_from_lexbuf lexbuf) }
+| '}'
+  { RBRACE (loc_from_lexbuf lexbuf) }
+| ';'
+  { SEMICOLON (loc_from_lexbuf lexbuf) }
+| '+'
+  { PLUS (loc_from_lexbuf lexbuf) }
+| '-'
+  { MINUS (loc_from_lexbuf lexbuf) }
+| '*'
+  { TIMES (loc_from_lexbuf lexbuf) }
+| '/'
+  { DIV (loc_from_lexbuf lexbuf) }
+| '%'
+  { MOD (loc_from_lexbuf lexbuf) }
+| "&&"
+  { LAND (loc_from_lexbuf lexbuf) }
+| "||"
+  { LOR (loc_from_lexbuf lexbuf) }
+| '&'
+  { BAND (loc_from_lexbuf lexbuf) }
+| '|'
+  { BOR (loc_from_lexbuf lexbuf) }
+| '^'
+  { BXOR (loc_from_lexbuf lexbuf) }
+| '>'
+  { GT (loc_from_lexbuf lexbuf) }
+| '<'
+  { LT (loc_from_lexbuf lexbuf) }
+| ">="
+  { GTE (loc_from_lexbuf lexbuf) }
+| "<="
+  { LTE (loc_from_lexbuf lexbuf) }
+| "=="
+  { EQ (loc_from_lexbuf lexbuf) }
+| "!="
+  { NEQ (loc_from_lexbuf lexbuf) }
+| '~'
+  { BNOT (loc_from_lexbuf lexbuf) }
+| '!'
+  { LNOT (loc_from_lexbuf lexbuf) }
+| '='
+  { ASSIGN (loc_from_lexbuf lexbuf) }
+| "++"
+  { INR (loc_from_lexbuf lexbuf) }
+| "--"
+  { DCR (loc_from_lexbuf lexbuf) }
+| "if"
+  { IF (loc_from_lexbuf lexbuf) }
+| "else"
+  { ELSE (loc_from_lexbuf lexbuf) }
+| "while"
+  { WHILE (loc_from_lexbuf lexbuf) }
+| "return"
+  { RETURN (loc_from_lexbuf lexbuf) }
+| "print"
+  { PRINT (loc_from_lexbuf lexbuf) }
+| "exit"
+  { EXIT (loc_from_lexbuf lexbuf) }
+| "int"
+  { INT (loc_from_lexbuf lexbuf) }
+| "void"
+  { VOID (loc_from_lexbuf lexbuf) }
+| ['a'-'z''A'-'Z''_']['a'-'z''A'-'Z''_''0'-'9']* as name
+    { IDENT (name, (loc_from_lexbuf lexbuf)) }
+| eof
+    { EOF }
+| _
+    { raise (Error 
+      ((Printf.sprintf 
+        "unexpected character '%s' at position %d:%d" 
+        (String.escaped (Lexing.lexeme lexbuf))
+        (Lexing.lexeme_start_p lexbuf).pos_lnum
+        (Lexing.lexeme_start lexbuf)), 
+      (loc_from_lexbuf lexbuf))) }

--- a/lang/compiler/parse.mly
+++ b/lang/compiler/parse.mly
@@ -173,6 +173,9 @@ stmt:
 
 // expressions
 expr:
+| start_loc = LPAREN e = expr end_loc = RPAREN
+  { let (e, _) = e in
+    (e, span start_loc end_loc) }
 | n = NUM
   { let (n, loc) = n in 
     (Num (n, loc), loc) }

--- a/lang/compiler/parse.mly
+++ b/lang/compiler/parse.mly
@@ -1,0 +1,266 @@
+%{
+  open Ast
+  open Util.Srcloc
+%}
+
+%token <int * Util.Srcloc.src_loc> NUM
+%token <string * Util.Srcloc.src_loc> IDENT
+
+%token <Util.Srcloc.src_loc> LPAREN
+%token <Util.Srcloc.src_loc> RPAREN
+%token <Util.Srcloc.src_loc> LBRACE
+%token <Util.Srcloc.src_loc> RBRACE
+%token <Util.Srcloc.src_loc> SEMICOLON
+
+%token <Util.Srcloc.src_loc> PLUS
+%token <Util.Srcloc.src_loc> MINUS
+%token <Util.Srcloc.src_loc> TIMES
+%token <Util.Srcloc.src_loc> DIV
+%token <Util.Srcloc.src_loc> MOD
+%token <Util.Srcloc.src_loc> BAND
+%token <Util.Srcloc.src_loc> BOR
+%token <Util.Srcloc.src_loc> BXOR
+%token <Util.Srcloc.src_loc> LAND
+%token <Util.Srcloc.src_loc> LOR
+%token <Util.Srcloc.src_loc> GT
+%token <Util.Srcloc.src_loc> LT
+%token <Util.Srcloc.src_loc> GTE
+%token <Util.Srcloc.src_loc> LTE
+%token <Util.Srcloc.src_loc> EQ
+%token <Util.Srcloc.src_loc> NEQ
+
+%token <Util.Srcloc.src_loc> BNOT
+%token <Util.Srcloc.src_loc> LNOT
+
+%token <Util.Srcloc.src_loc> ASSIGN
+%token <Util.Srcloc.src_loc> INR
+%token <Util.Srcloc.src_loc> DCR
+
+%token <Util.Srcloc.src_loc> IF
+%token <Util.Srcloc.src_loc> ELSE
+%token <Util.Srcloc.src_loc> WHILE
+%token <Util.Srcloc.src_loc> RETURN
+
+%token <Util.Srcloc.src_loc> PRINT
+%token <Util.Srcloc.src_loc> EXIT
+
+%token <Util.Srcloc.src_loc> INT
+%token <Util.Srcloc.src_loc> VOID
+
+%token EOF
+
+%start <func_defn list> program
+
+%%
+
+program:
+| fn = definition rest = program
+  { fn :: rest }
+| EOF 
+  { [] }
+
+definition:
+| t = typ name = IDENT LPAREN p = params RPAREN 
+  LBRACE b = stmt_list end_loc = RBRACE
+  {
+    let (return_ty, start_loc) = t in 
+    let (name, _) = name in 
+    {
+      name;
+      params= p;
+      body= b;
+      return_ty;
+      loc= span start_loc end_loc;
+    }
+  }
+
+typ:
+| loc = INT
+  { (Int, loc) }
+| loc = VOID
+  { (Void, loc) }
+
+params:
+| first = decl rest = params
+  { 
+    let (name, typ, _) = first in 
+    (name, typ) :: rest 
+  }
+| RPAREN 
+  { [] }
+
+decl:
+| t = typ name = IDENT
+  { 
+    let (t, start_loc) = t in 
+    let (name, end_loc) = name in
+    (name, t, span start_loc end_loc)
+  }
+
+stmt_list:
+| first = stmt SEMICOLON rest = stmt_list
+  { first :: rest }
+| first = block_stmt rest = stmt_list
+  { first :: rest }
+| RBRACE
+  { [] }
+
+block_stmt:
+| d = decl ASSIGN e = expr end_loc = SEMICOLON scope = stmt_list
+  {
+    let (name, typ, start_loc) = d in 
+    let (e, _) = e in 
+    Let (name, typ, e, scope, span start_loc end_loc)
+  }
+| start_loc = IF LPAREN cond = expr RPAREN 
+  LBRACE thn = stmt_list end_loc = RBRACE
+  { let (cond, _) = cond in 
+    If (cond, thn, span start_loc end_loc) }
+| start_loc = IF LPAREN cond = expr RPAREN LBRACE thn = stmt_list RBRACE 
+  ELSE LBRACE els = stmt_list end_loc = RBRACE
+  { let (cond, _) = cond in 
+    IfElse (cond, thn, els, span start_loc end_loc) }
+| start_loc = LBRACE stmts = stmt_list end_loc = RBRACE
+  { Block (stmts, span start_loc end_loc) }
+| start_loc = WHILE LPAREN cond = expr RPAREN LBRACE body = stmt_list end_loc = RBRACE
+  { let (cond, _) = cond in 
+    While (cond, body, span start_loc end_loc) }
+
+stmt:
+| var = IDENT ASSIGN e = expr
+  { 
+    let (var, start_loc) = var in 
+    let (e, end_loc) = e in 
+    Assign (var, e, span start_loc end_loc)
+  }
+| start_loc = RETURN e = expr 
+  {
+    let (e, end_loc) = e in 
+    Return (Some e, span start_loc end_loc)
+  }
+| loc = RETURN 
+  { Return (None, loc) }
+| e = expr 
+  { let (e, loc) = e in 
+    ExprStmt (e, loc) }
+| start_loc = PRINT LPAREN arg = expr end_loc = RPAREN
+  { let (arg, _) = arg in 
+    PrintDec (arg, span start_loc end_loc) }
+| var = IDENT end_loc = INR
+  { let (var, start_loc) = var in 
+    Inr (var, span start_loc end_loc) }
+| var = IDENT end_loc = DCR
+  { let (var, start_loc) = var in 
+    Dcr (var, span start_loc end_loc) }
+| start_loc = EXIT LPAREN arg = expr end_loc = RPAREN
+  { let (arg, _) = arg in 
+    Exit (Some arg, span start_loc end_loc) }
+| start_loc = EXIT LPAREN end_loc = RPAREN
+  { Exit (None, span start_loc end_loc) }
+
+expr:
+| n = NUM
+  { let (n, loc) = n in 
+    (Num (n, loc), loc) }
+| var = IDENT 
+  { let (var, loc) = var in 
+    (Var (var, loc), loc) }
+| fn = IDENT LPAREN args = arg_list end_loc = RPAREN
+  { let (fn, start_loc) = fn in 
+    let loc = span start_loc end_loc in 
+    (Call (fn, args, loc), loc) }
+| start_loc = BNOT e = expr 
+  { let (e, end_loc) = e in 
+    let loc = span start_loc end_loc in 
+    (UnOp (BNot, e, loc), loc) }
+| l = expr PLUS r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Plus, l, r, loc), loc) }
+| l = expr MINUS r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Minus, l, r, loc), loc) }
+| l = expr TIMES r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Mult, l, r, loc), loc) }
+| l = expr DIV r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Div, l, r, loc), loc) }
+| l = expr MOD r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Mod, l, r, loc), loc) }
+| l = expr BAND r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (BAnd, l, r, loc), loc) }
+| l = expr BOR r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (BOr, l, r, loc), loc) }
+| l = expr BXOR r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (BXor, l, r, loc), loc) }
+| l = expr GT r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Gt, l, r, loc), loc) }
+| l = expr LT r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Lt, l, r, loc), loc) }
+| l = expr GTE r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Gte, l, r, loc), loc) }
+| l = expr LTE r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Lte, l, r, loc), loc) }
+| l = expr EQ r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Eq, l, r, loc), loc) }
+| l = expr NEQ r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (Neq, l, r, loc), loc) }
+| l = expr LAND r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    ((LogOp ((LAnd (l, r)), loc)), loc) }
+| l = expr LOR r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    ((LogOp ((LOr (l, r)), loc)), loc) }
+| start_loc = LNOT e = expr 
+  { let (e, end_loc) = e in 
+    let loc = span start_loc end_loc in 
+    ((LogOp ((LNot e), loc)), loc) }
+
+arg_list:
+| first = expr rest = arg_list
+  { let (first, _) = first in 
+    first :: rest }
+| RPAREN
+  { [] }

--- a/lang/compiler/parser.ml
+++ b/lang/compiler/parser.ml
@@ -1,0 +1,22 @@
+open Stdlib
+open Printf
+open Ast
+open Util.Srcloc
+
+exception CompilerParseError of string * src_loc
+
+(* [parse] consumes a string representing a source program
+  and parses it into a list of function definitions *)
+let parse (s : string) : func_defn list =
+  let buf = Lexing.from_string s in
+  match Parse.program Lex.token buf with
+  | funcs -> funcs
+  | exception Lex.Error (msg, loc) -> raise (CompilerParseError (msg, loc))
+  | exception Parse.Error ->
+      let pos = Lexing.lexeme_start_p buf in
+      let msg =
+        sprintf "bad token '%s' on line %d"
+          (String.escaped (Lexing.lexeme buf))
+          pos.pos_lnum
+      in
+      raise (CompilerParseError (msg, loc_from_lexbuf buf))

--- a/lang/compiler/parser.ml
+++ b/lang/compiler/parser.ml
@@ -12,7 +12,7 @@ let prog_from_defns (defns : func_defn list) : prog =
   | Some main ->
       let funcs = List.filter (fun d -> d.name <> "main") defns in
       { main; funcs }
-  | None -> raise (CompilerParseError ("program had no main function", None))
+  | None -> raise (CompilerParseError ("missing main function", None))
 
 (* [parse] consumes a string representing a source program
   and parses it into a list of function definitions *)

--- a/lang/compiler/parser.ml
+++ b/lang/compiler/parser.ml
@@ -8,11 +8,11 @@ exception CompilerParseError of string * maybe_loc
 (* [prog_from_defns] converts a list of function definitions
   into a program, by extracting out the main function *)
 let prog_from_defns (defns : func_defn list) : prog =
-  match lookup "main" defns with
-  | Some main ->
-      let funcs = List.filter (fun d -> d.name <> "main") defns in
-      { main; funcs }
-  | None -> raise (CompilerParseError ("missing main function", None))
+  match List.partition (fun defn -> defn.name = "main") defns with
+  | [ main ], funcs -> { main; funcs }
+  | _ ->
+      raise
+        (CompilerParseError ("program must have exactly one main function", None))
 
 (* [parse] consumes a string representing a source program
   and parses it into a list of function definitions *)

--- a/lang/test/dune
+++ b/lang/test/dune
@@ -1,5 +1,5 @@
 (tests 
-  (names test_assembler test_emulator test_compiler)
+  (names test_assembler test_emulator test_compiler test_parser)
   (libraries ounit2 asm emulator compiler))
 
 (env

--- a/lang/test/test_parser.ml
+++ b/lang/test/test_parser.ml
@@ -3,8 +3,11 @@ open Compiler.Parser
 open Compiler.Ast
 open Util.Srcloc
 
+(* A dummy source location for testing purposes. *)
 let sl = loc 0 0
 
+(* [norm_src_locs] replaces all source locations in a program with 
+  one uniform source location. *)
 let norm_src_locs (pgrm : prog) =
   let rec norm_expr (exp : expr) =
     match exp with
@@ -41,31 +44,270 @@ let norm_src_locs (pgrm : prog) =
   let { funcs; main } = pgrm in
   { funcs = List.map norm_func funcs; main = norm_func main }
 
+(* [main_from_body] constructs an ast function defn that conforms
+  to what main functions must look like, with the given body filled in. *)
 let main_from_body (body : stmt list) : func_defn =
   { name = "main"; params = []; body; return_ty = Void; loc = sl }
 
 let empty_main = main_from_body []
 
+(* [assert_parses_to] tests that a given full program parses to 
+  the given program ast. *)
 let assert_parses_to (pgrm : string) (exp : prog) =
   let parsed = norm_src_locs (parse pgrm) in
   assert_equal parsed exp
 
+(* [assert_body_parses_to] asserts that the given text for the body 
+  of a main function parses to a program with the given stmt list 
+  as the body of its main function. This removes some of the overhead
+  of constructing full programs when testing individual constructs. *)
+let assert_body_parses_to (body : string) (exp_body : stmt list) =
+  let pgrm = Printf.sprintf "void main() { %s }" body in
+  let expected = { funcs = []; main = main_from_body exp_body } in
+  assert_parses_to pgrm expected
+
 let test_empty_main _ =
   assert_parses_to "void main() {}" { funcs = []; main = empty_main }
+
+let test_num _ =
+  assert_body_parses_to "1; -117; 0xc; -0b101;"
+    [
+      ExprStmt (Num (1, sl), sl);
+      ExprStmt (Num (-117, sl), sl);
+      ExprStmt (Num (0xc, sl), sl);
+      ExprStmt (Num (-0b101, sl), sl);
+    ]
+
+let test_var _ =
+  assert_body_parses_to "x; name_with_underscores; nameWithNum50;"
+    [
+      ExprStmt (Var ("x", sl), sl);
+      ExprStmt (Var ("name_with_underscores", sl), sl);
+      ExprStmt (Var ("nameWithNum50", sl), sl);
+    ]
+
+let test_un_op _ =
+  assert_body_parses_to "~7;" [ ExprStmt (UnOp (BNot, Num (7, sl), sl), sl) ]
+
+let test_bin_op _ =
+  assert_body_parses_to "4 + 5;"
+    [ ExprStmt (BinOp (Plus, Num (4, sl), Num (5, sl), sl), sl) ];
+  assert_body_parses_to "16 - 7;"
+    [ ExprStmt (BinOp (Minus, Num (16, sl), Num (7, sl), sl), sl) ];
+  assert_body_parses_to "100 * 2;"
+    [ ExprStmt (BinOp (Mult, Num (100, sl), Num (2, sl), sl), sl) ];
+  assert_body_parses_to "0xa / 5;"
+    [ ExprStmt (BinOp (Div, Num (0xa, sl), Num (5, sl), sl), sl) ];
+  assert_body_parses_to "120 % 10;"
+    [ ExprStmt (BinOp (Mod, Num (120, sl), Num (10, sl), sl), sl) ];
+  assert_body_parses_to "0b110 & 0b010;"
+    [ ExprStmt (BinOp (BAnd, Num (0b110, sl), Num (0b010, sl), sl), sl) ];
+  assert_body_parses_to "0b1111 | 0b1010;"
+    [ ExprStmt (BinOp (BOr, Num (0b1111, sl), Num (0b1010, sl), sl), sl) ];
+  assert_body_parses_to "0b01 ^ 0b01;"
+    [ ExprStmt (BinOp (BXor, Num (0b01, sl), Num (0b01, sl), sl), sl) ];
+  assert_body_parses_to "-6 > -10;"
+    [ ExprStmt (BinOp (Gt, Num (-6, sl), Num (-10, sl), sl), sl) ];
+  assert_body_parses_to "100 < 110;"
+    [ ExprStmt (BinOp (Lt, Num (100, sl), Num (110, sl), sl), sl) ];
+  assert_body_parses_to "81 >= 77;"
+    [ ExprStmt (BinOp (Gte, Num (81, sl), Num (77, sl), sl), sl) ];
+  assert_body_parses_to "-41 <= 4;"
+    [ ExprStmt (BinOp (Lte, Num (-41, sl), Num (4, sl), sl), sl) ];
+  assert_body_parses_to "16 == 48;"
+    [ ExprStmt (BinOp (Eq, Num (16, sl), Num (48, sl), sl), sl) ];
+  assert_body_parses_to "44 != -44;"
+    [ ExprStmt (BinOp (Neq, Num (44, sl), Num (-44, sl), sl), sl) ]
+
+let test_log_op _ =
+  assert_body_parses_to "1 && 0;"
+    [ ExprStmt (LogOp (LAnd (Num (1, sl), Num (0, sl)), sl), sl) ];
+  assert_body_parses_to "5 || 7;"
+    [ ExprStmt (LogOp (LOr (Num (5, sl), Num (7, sl)), sl), sl) ];
+  assert_body_parses_to "!17;"
+    [ ExprStmt (LogOp (LNot (Num (17, sl)), sl), sl) ]
+
+let test_precedence _ =
+  assert_body_parses_to "1 + 2 * 8 < (100 ^ 3) && ~7 == (40 & 18);"
+    [
+      ExprStmt
+        ( LogOp
+            ( LAnd
+                ( BinOp
+                    ( Lt,
+                      BinOp
+                        ( Plus,
+                          Num (1, sl),
+                          BinOp (Mult, Num (2, sl), Num (8, sl), sl),
+                          sl ),
+                      BinOp (BXor, Num (100, sl), Num (3, sl), sl),
+                      sl ),
+                  BinOp
+                    ( Eq,
+                      UnOp (BNot, Num (7, sl), sl),
+                      BinOp (BAnd, Num (40, sl), Num (18, sl), sl),
+                      sl ) ),
+              sl ),
+          sl );
+    ];
+  (* logical operators *)
+  assert_body_parses_to "!4 && 7 || !(6 && 23);"
+    [
+      ExprStmt
+        ( LogOp
+            ( LOr
+                ( LogOp (LAnd (LogOp (LNot (Num (4, sl)), sl), Num (7, sl)), sl),
+                  LogOp (LNot (LogOp (LAnd (Num (6, sl), Num (23, sl)), sl)), sl)
+                ),
+              sl ),
+          sl );
+    ]
+
+let test_assoc _ =
+  assert_body_parses_to "1 + 2 + 3 + 4;"
+    [
+      ExprStmt
+        ( BinOp
+            ( Plus,
+              BinOp
+                ( Plus,
+                  BinOp (Plus, Num (1, sl), Num (2, sl), sl),
+                  Num (3, sl),
+                  sl ),
+              Num (4, sl),
+              sl ),
+          sl );
+    ]
+
+let test_arbitrary_parens _ =
+  assert_body_parses_to "(((40)));" [ ExprStmt (Num (40, sl), sl) ]
+
+let test_let _ =
+  (* simple *)
+  let body = "int x = 70;" in
+  let body_stmts = [ Let ("x", Int, Num (70, sl), [], sl) ] in
+  assert_body_parses_to body body_stmts;
+  (* nested scope *)
+  let body = "int z = 1; int y = 2; z;" in
+  let body_stmts =
+    [
+      Let
+        ( "z",
+          Int,
+          Num (1, sl),
+          [ Let ("y", Int, Num (2, sl), [ ExprStmt (Var ("z", sl), sl) ], sl) ],
+          sl );
+    ]
+  in
+  assert_body_parses_to body body_stmts;
+  let body = "int first = 12; 1; 2; int second = first; 3;" in
+  let body_stmts =
+    [
+      Let
+        ( "first",
+          Int,
+          Num (12, sl),
+          [
+            ExprStmt (Num (1, sl), sl);
+            ExprStmt (Num (2, sl), sl);
+            Let
+              ( "second",
+                Int,
+                Var ("first", sl),
+                [ ExprStmt (Num (3, sl), sl) ],
+                sl );
+          ],
+          sl );
+    ]
+  in
+  assert_body_parses_to body body_stmts;
+  (* scope ends at end of block *)
+  let body = "int x = 10; { int y = x; } 1;" in
+  let body_stmts =
+    [
+      Let
+        ( "x",
+          Int,
+          Num (10, sl),
+          [
+            Block ([ Let ("y", Int, Var ("x", sl), [], sl) ], sl);
+            ExprStmt (Num (1, sl), sl);
+          ],
+          sl );
+    ]
+  in
+  assert_body_parses_to body body_stmts
+
+let test_assign _ =
+  assert_body_parses_to "int x = 0; x = 7;"
+    [ Let ("x", Int, Num (0, sl), [ Assign ("x", Num (7, sl), sl) ], sl) ]
+
+let test_if _ =
+  assert_body_parses_to "if (1) { 10; }"
+    [ If (Num (1, sl), [ ExprStmt (Num (10, sl), sl) ], sl) ]
+
+let test_if_else _ =
+  assert_body_parses_to "if (-5) { 1; } else { 0; }"
+    [
+      IfElse
+        ( Num (-5, sl),
+          [ ExprStmt (Num (1, sl), sl) ],
+          [ ExprStmt (Num (0, sl), sl) ],
+          sl );
+    ]
+
+let test_block _ =
+  assert_body_parses_to "{ 1; 2; { 3; } }"
+    [
+      Block
+        ( [
+            ExprStmt (Num (1, sl), sl);
+            ExprStmt (Num (2, sl), sl);
+            Block ([ ExprStmt (Num (3, sl), sl) ], sl);
+          ],
+          sl );
+    ]
+
+let test_return _ =
+  assert_body_parses_to "return; return 0;"
+    [ Return (None, sl); Return (Some (Num (0, sl)), sl) ]
+
+let test_exprstmt _ =
+  assert_body_parses_to "1 + 2; x;"
+    [
+      ExprStmt (BinOp (Plus, Num (1, sl), Num (2, sl), sl), sl);
+      ExprStmt (Var ("x", sl), sl);
+    ]
+
+let test_while _ =
+  assert_body_parses_to "while (1) { 5; }"
+    [ While (Num (1, sl), [ ExprStmt (Num (5, sl), sl) ], sl) ]
+
+let test_print_dec _ =
+  assert_body_parses_to "print(7);" [ PrintDec (Num (7, sl), sl) ]
+
+let test_inr _ =
+  assert_body_parses_to "x++; name++;" [ Inr ("x", sl); Inr ("name", sl) ]
+
+let test_dcr _ =
+  assert_body_parses_to "x--; name--;" [ Dcr ("x", sl); Dcr ("name", sl) ]
+
+let test_exit _ =
+  assert_body_parses_to "exit(); exit(-1);"
+    [ Exit (None, sl); Exit (Some (Num (-1, sl)), sl) ]
 
 let test_fact _ =
   let fact =
     "\n\
-    \    // fact(n) computes n!\n\
-    \    int fact(int n) {\n\
-    \      if (n == 0) {\n\
-    \        return 1;\n\
-    \      } else {\n\
-    \        return n * fact(n - 1);\n\
-    \      }\n\
-    \    }\n\n\
-    \    void main() {}\n\
-    \  "
+    \        // fact(n) computes n!\n\
+    \        int fact(int n) {\n\
+    \          if (n == 0) {\n\
+    \            return 1;\n\
+    \          } else {\n\
+    \            return n * fact(n - 1);\n\
+    \          }\n\
+    \        }\n\
+    \        void main() {}"
   in
   assert_parses_to fact
     {
@@ -106,6 +348,29 @@ let test_fact _ =
 
 let suite =
   "Source Language Parser Tests"
-  >::: [ "test_empty_main" >:: test_empty_main; "test_fact" >:: test_fact ]
+  >::: [
+         "test_empty_main" >:: test_empty_main;
+         "test_num" >:: test_num;
+         "test_var" >:: test_var;
+         "test_un_op" >:: test_un_op;
+         "test_bin_op" >:: test_bin_op;
+         "test_log_op" >:: test_log_op;
+         "test_precedence" >:: test_precedence;
+         "test_assoc" >:: test_assoc;
+         "test_arbitrary_parens" >:: test_arbitrary_parens;
+         "test_let" >:: test_let;
+         "test_assign" >:: test_assign;
+         "test_if" >:: test_if;
+         "test_if_else" >:: test_if_else;
+         "test_block" >:: test_block;
+         "test_return" >:: test_return;
+         "test_exprstmt" >:: test_exprstmt;
+         "test_while" >:: test_while;
+         "test_print_dec" >:: test_print_dec;
+         "test_inr" >:: test_inr;
+         "test_dcr" >:: test_dcr;
+         "test_exit" >:: test_exit;
+         "test_fact" >:: test_fact;
+       ]
 
 let () = run_test_tt_main suite

--- a/lang/test/test_parser.ml
+++ b/lang/test/test_parser.ml
@@ -1,0 +1,111 @@
+open OUnit2
+open Compiler.Parser
+open Compiler.Ast
+open Util.Srcloc
+
+let sl = loc 0 0
+
+let norm_src_locs (pgrm : prog) =
+  let rec norm_expr (exp : expr) =
+    match exp with
+    | Num (n, _) -> Num (n, sl)
+    | Var (id, _) -> Var (id, sl)
+    | UnOp (op, e, _) -> UnOp (op, norm_expr e, sl)
+    | BinOp (op, l, r, _) -> BinOp (op, norm_expr l, norm_expr r, sl)
+    | LogOp (LNot e, _) -> LogOp (LNot (norm_expr e), sl)
+    | LogOp (LAnd (l, r), _) -> LogOp (LAnd (norm_expr l, norm_expr r), sl)
+    | LogOp (LOr (l, r), _) -> LogOp (LOr (norm_expr l, norm_expr r), sl)
+    | Call (fn, args, _) -> Call (fn, List.map norm_expr args, sl)
+  and norm_stmt (stmt : stmt) =
+    match stmt with
+    | Let (id, typ, value, body, _) ->
+        Let (id, typ, norm_expr value, norm_stmt_list body, sl)
+    | Assign (id, exp, _) -> Assign (id, norm_expr exp, sl)
+    | If (cond, thn, _) -> If (norm_expr cond, norm_stmt_list thn, sl)
+    | IfElse (cond, thn, els, _) ->
+        IfElse (norm_expr cond, norm_stmt_list thn, norm_stmt_list els, sl)
+    | Block (stmts, _) -> Block (norm_stmt_list stmts, sl)
+    | Return (Some e, _) -> Return (Some (norm_expr e), sl)
+    | Return (None, _) -> Return (None, sl)
+    | ExprStmt (e, _) -> ExprStmt (norm_expr e, sl)
+    | While (cond, body, _) -> While (norm_expr cond, norm_stmt_list body, sl)
+    | PrintDec (e, _) -> PrintDec (norm_expr e, sl)
+    | Inr (name, _) -> Inr (name, sl)
+    | Dcr (name, _) -> Dcr (name, sl)
+    | Exit (Some e, _) -> Exit (Some (norm_expr e), sl)
+    | Exit (None, _) -> Exit (None, sl)
+  and norm_stmt_list (stmts : stmt list) = List.map norm_stmt stmts
+  and norm_func (func : func_defn) =
+    { func with body = norm_stmt_list func.body; loc = sl }
+  in
+  let { funcs; main } = pgrm in
+  { funcs = List.map norm_func funcs; main = norm_func main }
+
+let main_from_body (body : stmt list) : func_defn =
+  { name = "main"; params = []; body; return_ty = Void; loc = sl }
+
+let empty_main = main_from_body []
+
+let assert_parses_to (pgrm : string) (exp : prog) =
+  let parsed = norm_src_locs (parse pgrm) in
+  assert_equal parsed exp
+
+let test_empty_main _ =
+  assert_parses_to "void main() {}" { funcs = []; main = empty_main }
+
+let test_fact _ =
+  let fact =
+    "\n\
+    \    // fact(n) computes n!\n\
+    \    int fact(int n) {\n\
+    \      if (n == 0) {\n\
+    \        return 1;\n\
+    \      } else {\n\
+    \        return n * fact(n - 1);\n\
+    \      }\n\
+    \    }\n\n\
+    \    void main() {}\n\
+    \  "
+  in
+  assert_parses_to fact
+    {
+      funcs =
+        [
+          {
+            name = "fact";
+            params = [ ("n", Int) ];
+            body =
+              [
+                IfElse
+                  ( BinOp (Eq, Var ("n", sl), Num (0, sl), sl),
+                    [ Return (Some (Num (1, sl)), sl) ],
+                    [
+                      Return
+                        ( Some
+                            (BinOp
+                               ( Mult,
+                                 Var ("n", sl),
+                                 Call
+                                   ( "fact",
+                                     [
+                                       BinOp
+                                         (Minus, Var ("n", sl), Num (1, sl), sl);
+                                     ],
+                                     sl ),
+                                 sl )),
+                          sl );
+                    ],
+                    sl );
+              ];
+            return_ty = Int;
+            loc = sl;
+          };
+        ];
+      main = empty_main;
+    }
+
+let suite =
+  "Source Language Parser Tests"
+  >::: [ "test_empty_main" >:: test_empty_main; "test_fact" >:: test_fact ]
+
+let () = run_test_tt_main suite

--- a/lang/util/srcloc.ml
+++ b/lang/util/srcloc.ml
@@ -22,6 +22,11 @@ let loc_from_lexbuf (buf : lexbuf) =
   let lno = (lexeme_start_p buf).pos_lnum in
   loc lno lno
 
+(* [span] constructs a new source location representing 
+  the span of two given source locations. *)
+let span (min_loc : src_loc) (max_loc : src_loc) : src_loc =
+  loc min_loc.startl max_loc.endl
+
 (* the periphery is how many lines above and below the source 
   location are printed when the location is printed *)
 let periphery = 2

--- a/programs/syntax_proposal.3000.c
+++ b/programs/syntax_proposal.3000.c
@@ -11,6 +11,7 @@ void main() {
   10 - 4;
   5 * 7;
   6 / 2;
+  10 % 2;
   2 & 4;  // bitwise and
   7 | 8;  // bitwise or
   10 ^ 2; // bitwise xor


### PR DESCRIPTION
Adds a parser for the 3000 source language. Tests are in `test/test_parser.ml`. The syntax is C-like and generally follows the operator precedence/associativity found [here](https://en.cppreference.com/w/c/language/operator_precedence).