### PR TITLE
remove log_op type and refactor

### DIFF
--- a/lang/compiler/optimizations/constant_fold.ml
+++ b/lang/compiler/optimizations/constant_fold.ml
@@ -1,4 +1,5 @@
 open Ast
+open Util.Err
 
 (* [fold_expr] performs constant folding on a given expression. *)
 let rec fold_expr (exp : expr) : expr =
@@ -6,12 +7,21 @@ let rec fold_expr (exp : expr) : expr =
   | UnOp (op, expr, loc) -> (
       let folded_operand = fold_expr expr in
       match folded_operand with
-      | Num (n, _) -> ( match op with BNot -> Num (lnot n, loc))
+      | Num (n, _) -> (
+          match op with
+          | BNot -> Num (lnot n, loc)
+          | LNot -> Num ((if n = 0 then 1 else 0), loc))
       | _ -> UnOp (op, folded_operand, loc))
   | BinOp (op, left, right, loc) -> (
       let bool_to_3000_bool (b : bool) : int = if b then 1 else 0 in
-      match (fold_expr left, fold_expr right) with
-      | Num (left_value, _), Num (right_value, _) -> (
+      match (op, fold_expr left, fold_expr right) with
+      | LAnd, Num (left_value, _), folded_right ->
+          (* When left is false, fold to 0; otherwise fold to righthand value *)
+          if left_value = 0 then Num (0, loc) else folded_right
+      | LOr, Num (left_value, _), folded_right ->
+          (* When left is truthy, fold to it; otherwise, fold to righthand value *)
+          if left_value <> 0 then Num (left_value, loc) else folded_right
+      | _, Num (left_value, _), Num (right_value, _) -> (
           match op with
           | Plus -> Num (left_value + right_value, loc)
           | Minus -> Num (left_value - right_value, loc)
@@ -26,30 +36,15 @@ let rec fold_expr (exp : expr) : expr =
           | Gte -> Num (bool_to_3000_bool (left_value >= right_value), loc)
           | Lte -> Num (bool_to_3000_bool (left_value <= right_value), loc)
           | Eq -> Num (bool_to_3000_bool (left_value = right_value), loc)
-          | Neq -> Num (bool_to_3000_bool (left_value <> right_value), loc))
-      | folded_left, folded_right -> BinOp (op, folded_left, folded_right, loc))
-  | LogOp (op, loc) -> (
-      match op with
-      | LAnd (left, right) -> (
-          match (fold_expr left, fold_expr right) with
-          | Num (left_value, _), Num (right_value, _) ->
-              if left_value = 0 then Num (0, loc) else Num (right_value, loc)
-          | folded_left, folded_right ->
-              LogOp (LAnd (folded_left, folded_right), loc))
-      | LOr (left, right) -> (
-          match (fold_expr left, fold_expr right) with
-          | Num (left_value, _), Num (right_value, _) ->
-              if left_value <> 0 then Num (left_value, loc)
-              else Num (right_value, loc)
-          | folded_left, folded_right ->
-              LogOp (LOr (folded_left, folded_right), loc))
-      | LNot operand -> (
-          match fold_expr operand with
-          | Num (operand_value, _) ->
-              if operand_value = 0 then Num (1, loc) else Num (0, loc)
-          | folded_operand -> LogOp (LNot folded_operand, loc)))
+          | Neq -> Num (bool_to_3000_bool (left_value <> right_value), loc)
+          | LAnd | LOr ->
+              raise
+                (InternalError
+                   "unreachable match arm reached in constant folding"))
+      | _, folded_left, folded_right ->
+          BinOp (op, folded_left, folded_right, loc))
   | Call (name, args, loc) -> Call (name, List.map fold_expr args, loc)
-  | _ -> exp
+  | Num _ | Var _ -> exp
 
 (* [fold_stmt] performs constant folding on a single statement. *)
 and fold_stmt (stmt : stmt) : stmt =
@@ -80,7 +75,7 @@ and fold_stmt (stmt : stmt) : stmt =
   | PrintDec (expr, loc) -> PrintDec (fold_expr expr, loc)
   | Exit (Some expr, loc) -> Exit (Some (fold_expr expr), loc)
   | Assert (expr, loc) -> Assert (fold_expr expr, loc)
-  | _ -> stmt
+  | Return _ | Exit _ | Inr _ | Dcr _ -> stmt
 
 (* [fold_stmt_list] performs constant folding on a list of statements. *)
 and fold_stmt_list (stmts : stmt list) : stmt list = List.map fold_stmt stmts

--- a/lang/compiler/parser/parse.mly
+++ b/lang/compiler/parser/parse.mly
@@ -211,6 +211,10 @@ expr:
   { let (e, end_loc) = e in 
     let loc = span start_loc end_loc in 
     (UnOp (BNot, e, Some loc), loc) }
+| start_loc = LNOT e = expr 
+  { let (e, end_loc) = e in 
+    let loc = span start_loc end_loc in 
+    (UnOp (LNot, e, Some loc), loc) }
 | l = expr PLUS r = expr 
   { let (l, start_loc) = l in 
     let (r, end_loc) = r in 
@@ -251,6 +255,16 @@ expr:
     let (r, end_loc) = r in 
     let loc = span start_loc end_loc in 
     (BinOp (BXor, l, r, Some loc), loc) }
+| l = expr LAND r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (LAnd, l, r, Some loc), loc) }
+| l = expr LOR r = expr 
+  { let (l, start_loc) = l in 
+    let (r, end_loc) = r in 
+    let loc = span start_loc end_loc in 
+    (BinOp (LOr, l, r, Some loc), loc) }
 | l = expr GT r = expr 
   { let (l, start_loc) = l in 
     let (r, end_loc) = r in 
@@ -281,20 +295,6 @@ expr:
     let (r, end_loc) = r in 
     let loc = span start_loc end_loc in 
     (BinOp (Neq, l, r, Some loc), loc) }
-| l = expr LAND r = expr 
-  { let (l, start_loc) = l in 
-    let (r, end_loc) = r in 
-    let loc = span start_loc end_loc in 
-    ((LogOp ((LAnd (l, r)), Some loc)), loc) }
-| l = expr LOR r = expr 
-  { let (l, start_loc) = l in 
-    let (r, end_loc) = r in 
-    let loc = span start_loc end_loc in 
-    ((LogOp ((LOr (l, r)), Some loc)), loc) }
-| start_loc = LNOT e = expr 
-  { let (e, end_loc) = e in 
-    let loc = span start_loc end_loc in 
-    ((LogOp ((LNot e), Some loc)), loc) }
 
 // argument list of expressions for function calls
 arg_list:

--- a/lang/compiler/preprocess.ml
+++ b/lang/compiler/preprocess.ml
@@ -10,11 +10,6 @@ let rec expand_in_expr (define : pp_define) (exp : expr) : expr =
   | UnOp (op, expr, loc) -> UnOp (op, expand_in_expr define expr, loc)
   | BinOp (op, left, right, loc) ->
       BinOp (op, expand_in_expr define left, expand_in_expr define right, loc)
-  | LogOp (LNot expr, loc) -> LogOp (LNot (expand_in_expr define expr), loc)
-  | LogOp (LAnd (left, right), loc) ->
-      LogOp (LAnd (expand_in_expr define left, expand_in_expr define right), loc)
-  | LogOp (LOr (left, right), loc) ->
-      LogOp (LOr (expand_in_expr define left, expand_in_expr define right), loc)
   | Call (name, args, loc) ->
       Call (name, List.map (fun arg -> expand_in_expr define arg) args, loc)
 
@@ -45,7 +40,7 @@ and expand_in_stmt (define : pp_define) (stmt : stmt) : stmt =
   | PrintDec (expr, loc) -> PrintDec (expand_in_expr define expr, loc)
   | Exit (Some expr, loc) -> Exit (Some (expand_in_expr define expr), loc)
   | Assert (expr, loc) -> Assert (expand_in_expr define expr, loc)
-  | _ -> stmt
+  | Return _ | Exit _ | Inr _ | Dcr _ -> stmt
 
 (* [expand_in_stmt_list] expands a #define directive in every statement
   in a list. *)

--- a/lang/compiler/prettyprint.ml
+++ b/lang/compiler/prettyprint.ml
@@ -4,31 +4,17 @@ open Printf
 (* [indent] returns a string representing the given level of indentation. *)
 let rec indent (lvl : int) = if lvl = 0 then "" else "  " ^ indent (lvl - 1)
 
-(* [pretty_print_expr] converts an expression into a pretty-printed string. *)
-let rec pretty_print_expr (exp : expr) (is_sub_expr : bool) : string =
-  match exp with
-  | Num (n, _) -> sprintf "%d" n
-  | Var (name, _) -> name
-  | UnOp (op, operand, _) ->
-      pretty_print_un_op op (pretty_print_expr operand true)
-  | BinOp (op, left, right, _) ->
-      pretty_print_bin_op op
-        (pretty_print_expr left true)
-        (pretty_print_expr right true)
-        is_sub_expr
-  | LogOp (op, _) -> pretty_print_log_op op is_sub_expr
-  | Call (name, args, _) ->
-      sprintf "%s(%s)" name
-        (List.map (fun arg -> pretty_print_expr arg false) args
-        |> String.concat ", ")
-
 (* [pretty_print_un_op] converts a unary operator into a pretty-printed string. *)
-and pretty_print_un_op (op : un_op) (pretty_operand : string) : string =
-  match op with BNot -> sprintf "~%s" pretty_operand
+let pretty_print_un_op ?(is_nested_in_op = false) (op : un_op)
+    (pretty_operand : string) : string =
+  let pretty_un_op = function BNot -> "~" | LNot -> "!" in
+  sprintf
+    (if is_nested_in_op then "%s%s" else "%s(%s)")
+    (pretty_un_op op) pretty_operand
 
 (* [pretty_print_bin_op] converts a binary operator into a pretty-printed string. *)
-and pretty_print_bin_op (op : bin_op) (pretty_left : string)
-    (pretty_right : string) (is_sub_expr : bool) : string =
+let pretty_print_bin_op ?(is_nested_in_op = false) (op : bin_op)
+    (pretty_left : string) (pretty_right : string) : string =
   let pretty_bin_op = function
     | Plus -> "+"
     | Minus -> "-"
@@ -44,63 +30,57 @@ and pretty_print_bin_op (op : bin_op) (pretty_left : string)
     | Lte -> "<="
     | Eq -> "=="
     | Neq -> "!="
+    | LAnd -> "&&"
+    | LOr -> "||"
   in
-  let pretty_body =
-    sprintf "%s %s %s" pretty_left (pretty_bin_op op) pretty_right
-  in
-  if is_sub_expr then "(" ^ pretty_body ^ ")" else pretty_body
+  sprintf
+    (if is_nested_in_op then "(%s)" else "%s")
+    (sprintf "%s %s %s" pretty_left (pretty_bin_op op) pretty_right)
 
-(* [pretty_print_log_op] converts a logical operator into a pretty-printed string. *)
-and pretty_print_log_op (op : log_op) (is_sub_expr : bool) : string =
-  match op with
-  | LNot expr -> sprintf "!%s" (pretty_print_expr expr true)
-  | LAnd (left, right) ->
-      let pretty_land =
-        sprintf "%s && %s"
-          (pretty_print_expr left true)
-          (pretty_print_expr right true)
-      in
-      if is_sub_expr then "(" ^ pretty_land ^ ")" else pretty_land
-  | LOr (left, right) ->
-      let pretty_lor =
-        sprintf "%s || %s"
-          (pretty_print_expr left true)
-          (pretty_print_expr right true)
-      in
-      if is_sub_expr then "(" ^ pretty_lor ^ ")" else pretty_lor
+(* [pretty_print_expr] converts an expression into a pretty-printed string. *)
+let rec pretty_print_expr ?(is_nested_in_op = false) (exp : expr) : string =
+  match exp with
+  | Num (n, _) -> sprintf "%d" n
+  | Var (name, _) -> name
+  | UnOp (op, operand, _) ->
+      pretty_print_un_op op (pretty_print_expr operand ~is_nested_in_op:true)
+  | BinOp (op, left, right, _) ->
+      pretty_print_bin_op op
+        (pretty_print_expr left ~is_nested_in_op:true)
+        (pretty_print_expr right ~is_nested_in_op:true)
+        ~is_nested_in_op
+  | Call (name, args, _) ->
+      sprintf "%s(%s)" name
+        (List.map pretty_print_expr args |> String.concat ", ")
 
 (* [pretty_print_stmt] converts a single statement into a pretty-printed string. *)
 and pretty_print_stmt (stmt : stmt) (indent_level : int) : string =
   match stmt with
   | Let (name, typ, expr, scope, _) ->
       sprintf "%s %s = %s;\n%s" (pretty_print_type typ) name
-        (pretty_print_expr expr false)
+        (pretty_print_expr expr)
         (pretty_print_stmt_list scope indent_level)
-  | Assign (name, expr, _) ->
-      sprintf "%s = %s;" name (pretty_print_expr expr false)
+  | Assign (name, expr, _) -> sprintf "%s = %s;" name (pretty_print_expr expr)
   | If (cond, thn, _) ->
-      sprintf "if (%s) %s"
-        (pretty_print_expr cond false)
+      sprintf "if (%s) %s" (pretty_print_expr cond)
         (pretty_print_block thn indent_level)
   | IfElse (cond, thn, els, _) ->
-      sprintf "if (%s) %s else %s"
-        (pretty_print_expr cond false)
+      sprintf "if (%s) %s else %s" (pretty_print_expr cond)
         (pretty_print_block thn indent_level)
         (pretty_print_block els indent_level)
   | While (cond, body, _) ->
-      sprintf "while (%s) %s"
-        (pretty_print_expr cond false)
+      sprintf "while (%s) %s" (pretty_print_expr cond)
         (pretty_print_block body indent_level)
   | Block (body, _) -> pretty_print_block body indent_level
-  | Return (Some expr, _) -> sprintf "return %s;" (pretty_print_expr expr false)
+  | Return (Some expr, _) -> sprintf "return %s;" (pretty_print_expr expr)
   | Return (None, _) -> "return;"
-  | Exit (Some expr, _) -> sprintf "exit(%s);" (pretty_print_expr expr false)
+  | Exit (Some expr, _) -> sprintf "exit(%s);" (pretty_print_expr expr)
   | Exit (None, _) -> "exit();"
-  | ExprStmt (expr, _) -> sprintf "%s;" (pretty_print_expr expr false)
-  | PrintDec (expr, _) -> sprintf "print(%s);" (pretty_print_expr expr false)
+  | ExprStmt (expr, _) -> sprintf "%s;" (pretty_print_expr expr)
+  | PrintDec (expr, _) -> sprintf "print(%s);" (pretty_print_expr expr)
   | Inr (name, _) -> sprintf "%s++;" name
   | Dcr (name, _) -> sprintf "%s--;" name
-  | Assert (expr, _) -> sprintf "assert(%s);" (pretty_print_expr expr false)
+  | Assert (expr, _) -> sprintf "assert(%s);" (pretty_print_expr expr)
 
 (* [pretty_print_stmt_list] converts a statement list into a pretty-printed string. *)
 and pretty_print_stmt_list (stmts : stmt list) (indent_level : int) : string =
@@ -139,7 +119,7 @@ and pretty_print_func_defn (defn : func_defn) : string =
 
 (* [pretty_print_define] converts a #define directive into a pretty-printed string. *)
 and pretty_print_define (define : pp_define) : string =
-  sprintf "#define %s %s" define.var (pretty_print_expr define.expression false)
+  sprintf "#define %s %s" define.var (pretty_print_expr define.expression)
 
 (* [pretty_print] takes a program and produces a string that is 
   the program's text formatted nicely.  *)

--- a/lang/emulator/emulator.ml
+++ b/lang/emulator/emulator.ml
@@ -246,7 +246,7 @@ let emulate_instr (ins : instr) (machine : stew_3000) (label_to_addr : int env)
   | Label _ | Nop _ -> inc_pc ()
   (* XXX: Dic and Did not currently supported *)
   | Dic _ | Did _ -> inc_pc ()
-  | _ ->
+  | Cmpi (Imm _, Imm _, _) | Cmpi (Reg _, Reg _, _) ->
       raise
         (InternalError
            (sprintf "emulator: invalid instruction: %s" (string_of_instr ins)))

--- a/lang/test/test_checker.ml
+++ b/lang/test/test_checker.ml
@@ -16,7 +16,10 @@ let norm_check_err (err : Check.check_err) =
   | InvalidTypeError (e, act) -> InvalidTypeError (norm_expr_locs e, act)
   | TypeMismatch (name, op1, ty1, op2, ty2) ->
       TypeMismatch (name, norm_expr_locs op1, ty1, norm_expr_locs op2, ty2)
-  | _ -> err
+  | NonVoidMain | ReturnInMain | CtrlReachesEndOfNonVoid _ | MismatchedReturn _
+  | UnboundVariable _ | UndefinedFunction _ | NonFunctionAnnotatedAsVoid _
+  | ArityMismatch _ | MultipleDefinitions _ ->
+      err
 
 (* [assert_raises_check_err] runs a thunk and checks if it
   raises the indicated CheckError *)

--- a/lang/test/test_parser.ml
+++ b/lang/test/test_parser.ml
@@ -91,32 +91,32 @@ let test_bin_op _ =
 
 let test_log_op _ =
   assert_body_parses_to "1 && 0;"
-    [ ExprStmt (LogOp (LAnd (Num (1, None), Num (0, None)), None), None) ];
+    [ ExprStmt (BinOp (LAnd, Num (1, None), Num (0, None), None), None) ];
   assert_body_parses_to "5 || 7;"
-    [ ExprStmt (LogOp (LOr (Num (5, None), Num (7, None)), None), None) ];
+    [ ExprStmt (BinOp (LOr, Num (5, None), Num (7, None), None), None) ];
   assert_body_parses_to "!17;"
-    [ ExprStmt (LogOp (LNot (Num (17, None)), None), None) ]
+    [ ExprStmt (UnOp (LNot, Num (17, None), None), None) ]
 
 let test_precedence _ =
   assert_body_parses_to "1 + 2 * 8 < (100 ^ 3) && ~7 == (40 & 18);"
     [
       ExprStmt
-        ( LogOp
-            ( LAnd
-                ( BinOp
-                    ( Lt,
-                      BinOp
-                        ( Plus,
-                          Num (1, None),
-                          BinOp (Mult, Num (2, None), Num (8, None), None),
-                          None ),
-                      BinOp (BXor, Num (100, None), Num (3, None), None),
-                      None ),
+        ( BinOp
+            ( LAnd,
+              BinOp
+                ( Lt,
                   BinOp
-                    ( Eq,
-                      UnOp (BNot, Num (7, None), None),
-                      BinOp (BAnd, Num (40, None), Num (18, None), None),
-                      None ) ),
+                    ( Plus,
+                      Num (1, None),
+                      BinOp (Mult, Num (2, None), Num (8, None), None),
+                      None ),
+                  BinOp (BXor, Num (100, None), Num (3, None), None),
+                  None ),
+              BinOp
+                ( Eq,
+                  UnOp (BNot, Num (7, None), None),
+                  BinOp (BAnd, Num (40, None), Num (18, None), None),
+                  None ),
               None ),
           None );
     ];
@@ -124,14 +124,11 @@ let test_precedence _ =
   assert_body_parses_to "!4 && 7 || !(6 && 23);"
     [
       ExprStmt
-        ( LogOp
-            ( LOr
-                ( LogOp
-                    ( LAnd (LogOp (LNot (Num (4, None)), None), Num (7, None)),
-                      None ),
-                  LogOp
-                    ( LNot (LogOp (LAnd (Num (6, None), Num (23, None)), None)),
-                      None ) ),
+        ( BinOp
+            ( LOr,
+              BinOp (LAnd, UnOp (LNot, Num (4, None), None), Num (7, None), None),
+              UnOp
+                (LNot, BinOp (LAnd, Num (6, None), Num (23, None), None), None),
               None ),
           None );
     ]

--- a/lang/test/testing_utils.ml
+++ b/lang/test/testing_utils.ml
@@ -9,11 +9,6 @@ let rec norm_expr_locs (exp : expr) : expr =
   | Var (id, _) -> Var (id, None)
   | UnOp (op, e, _) -> UnOp (op, norm_expr_locs e, None)
   | BinOp (op, l, r, _) -> BinOp (op, norm_expr_locs l, norm_expr_locs r, None)
-  | LogOp (LNot e, _) -> LogOp (LNot (norm_expr_locs e), None)
-  | LogOp (LAnd (l, r), _) ->
-      LogOp (LAnd (norm_expr_locs l, norm_expr_locs r), None)
-  | LogOp (LOr (l, r), _) ->
-      LogOp (LOr (norm_expr_locs l, norm_expr_locs r), None)
   | Call (fn, args, _) -> Call (fn, List.map norm_expr_locs args, None)
 
 (* [norm_stmt_locs] normalizes source locations in a statement *)


### PR DESCRIPTION
I removed the `log_op` type and made `LAnd`, `LOr`, and `LNot` regular `bin_op`s and `un_op` respectively. 

I also tried to reduce usage of the catch-all `_` pattern. Having pattern matches that are exhaustive without using this pattern means that when we add to the `expr` or `stmt` types, OCaml will flag all the non-exhaustive patterns and it is less likely that somewhere we need to modify will silently slip by.