### PR TITLE
add check error for unrepresentable numbers in compiler

### DIFF
--- a/lang/bin/compile.ml
+++ b/lang/bin/compile.ml
@@ -30,6 +30,8 @@ let command =
           (* TEMP: pretty print the ast after preprocessing as sanity check *)
           Printf.printf "%s\n" (Prettyprint.pretty_print pgrm);
 
+          (* check again, post-optimization (catch folded unrepresentable values) *)
+          Check.check pgrm;
           let instrs = Compile.compile pgrm ~ignore_asserts in
 
           (* write generated asm to target file *)

--- a/lang/compiler/check.ml
+++ b/lang/compiler/check.ml
@@ -29,45 +29,47 @@ type check_err =
   | MultipleDefinitions of string
   (* Returned from main *)
   | ReturnInMain
+  (* Program contains a constant value outside the representable range *)
+  | UnrepresentableNumber of int
 
 exception CheckError of check_err with_loc_opt
 
 (* [string_of_check_err] turns a check error into a printable string. *)
 let string_of_check_err = function
   | CtrlReachesEndOfNonVoid name ->
-      sprintf "Control can reach the end of non-void function `%s`." name
+      sprintf "control can reach the end of non-void function `%s`." name
   | MismatchedReturn (name, return_ty) ->
-      sprintf "The %s function `%s` must return %s." (string_of_ty return_ty)
+      sprintf "the %s function `%s` must return %s." (string_of_ty return_ty)
         name
         (if return_ty = Void then "nothing"
         else sprintf "a value of type %s" (string_of_ty return_ty))
-  | UnboundVariable var -> sprintf "The variable `%s` is unbound." var
-  | UndefinedFunction name -> sprintf "The function `%s` is undefined." name
+  | UnboundVariable var -> sprintf "variable `%s` is unbound." var
+  | UndefinedFunction name -> sprintf "function `%s` is undefined." name
   | TypeError (e, expected, actual) ->
       sprintf
-        "The type of this %s expression was expected to be %s, but was %s."
+        "the type of this %s expression was expected to be %s, but was %s."
         (describe_expr e) (string_of_ty expected) (string_of_ty actual)
   | InvalidTypeError (e, actual) ->
-      sprintf "Expected this %s expression to not have type %s."
+      sprintf "expected this %s expression to not have type %s."
         (describe_expr e) (string_of_ty actual)
   | TypeMismatch (op_name, left, left_ty, right, right_ty) ->
       sprintf
-        "Operation %s expected the %s expression (of type %s) to be the same \
+        "operation %s expected the %s expression (of type %s) to be the same \
          type as the %s expression (of type %s)"
         op_name (describe_expr left) (string_of_ty left_ty)
         (describe_expr right) (string_of_ty right_ty)
-  | NonVoidMain -> "The main function must have return type void."
+  | NonVoidMain -> "the `main` function must have return type void."
   | NonFunctionAnnotatedAsVoid name ->
       sprintf "`%s` is not a function and therefore cannot have type void." name
   | ArityMismatch (name, expected, actual) ->
-      sprintf "The function `%s` expects %d argument%s, but got %d." name
-        expected
+      sprintf "function `%s` expects %d argument%s, but got %d." name expected
         (if expected = 1 then "" else "s")
         actual
   | MultipleDefinitions name ->
-      sprintf "The function `%s` has multiple definitions." name
+      sprintf "function `%s` has multiple definitions." name
   | ReturnInMain ->
-      "Cannot return from main function. Consider using exit() instead."
+      "cannot return from main function. Consider using exit() instead."
+  | UnrepresentableNumber n -> sprintf "unrepresentable value: %d" n
 
 (* [ctrl_reaches_end] determines if the control flow of a function's
   body can reach the end of the function without encountering a return. *)
@@ -115,7 +117,10 @@ let type_check (defn : func_defn) (defns : func_defn list) =
      or raises an error if it violates type rules. *)
   let rec type_check_expr (exp : expr) (env : ty env) : ty =
     match exp with
-    | Num _ -> Int
+    | Num (n, loc) ->
+        if n < -128 || n > 255 then
+          raise (CheckError (UnrepresentableNumber n, loc));
+        Int
     | Var (name, loc) -> lookup_var name env loc
     | UnOp (LNot, expr, _) ->
         (* expression needs to be type checked and cannot be void *)

--- a/lang/compiler/check.ml
+++ b/lang/compiler/check.ml
@@ -118,7 +118,8 @@ let type_check (defn : func_defn) (defns : func_defn list) =
   let rec type_check_expr (exp : expr) (env : ty env) : ty =
     match exp with
     | Num (n, loc) ->
-        if n < -128 || n > 255 then
+        (* all numbers are signed 8-bit *)
+        if n < -128 || n > 127 then
           raise (CheckError (UnrepresentableNumber n, loc));
         Int
     | Var (name, loc) -> lookup_var name env loc

--- a/lang/test/test_checker.ml
+++ b/lang/test/test_checker.ml
@@ -18,7 +18,7 @@ let norm_check_err (err : Check.check_err) =
       TypeMismatch (name, norm_expr_locs op1, ty1, norm_expr_locs op2, ty2)
   | NonVoidMain | ReturnInMain | CtrlReachesEndOfNonVoid _ | MismatchedReturn _
   | UnboundVariable _ | UndefinedFunction _ | NonFunctionAnnotatedAsVoid _
-  | ArityMismatch _ | MultipleDefinitions _ ->
+  | ArityMismatch _ | MultipleDefinitions _ | UnrepresentableNumber _ ->
       err
 
 (* [assert_raises_check_err] runs a thunk and checks if it
@@ -135,6 +135,12 @@ let test_ret_in_main _ =
     "void main() { if (10 > 11) { return 5; } else {} }";
   assert_raises_check_err ReturnInMain "void main() { while (1) { return; } }"
 
+let test_unrepresentable_number _ =
+  assert_raises_check_err (UnrepresentableNumber 256)
+    "void main() { print(256); }";
+  assert_raises_check_err (UnrepresentableNumber (-129))
+    "void main() { if (0 < -129) { exit(-1); } }"
+
 let suite =
   "Checker Tests"
   >::: [
@@ -150,6 +156,7 @@ let suite =
          "test_arity_mismatch" >:: test_arity_mismatch;
          "test_mult_defns" >:: test_mult_defns;
          "test_ret_in_main" >:: test_ret_in_main;
+         "test_unrepresentable_number" >:: test_unrepresentable_number;
        ]
 
 let () = run_test_tt_main suite

--- a/lang/test/test_checker.ml
+++ b/lang/test/test_checker.ml
@@ -136,8 +136,8 @@ let test_ret_in_main _ =
   assert_raises_check_err ReturnInMain "void main() { while (1) { return; } }"
 
 let test_unrepresentable_number _ =
-  assert_raises_check_err (UnrepresentableNumber 256)
-    "void main() { print(256); }";
+  assert_raises_check_err (UnrepresentableNumber 128)
+    "void main() { print(128); }";
   assert_raises_check_err (UnrepresentableNumber (-129))
     "void main() { if (0 < -129) { exit(-1); } }"
 

--- a/lang/test/test_compiler.ml
+++ b/lang/test/test_compiler.ml
@@ -90,8 +90,8 @@ let test_nums _ =
 
 let test_unops _ =
   (* bitwise not *)
-  assert_a "~0b11111111;" 0b00000000;
-  assert_a "~0b10010111;" 0b01101000
+  assert_a "~0b00001011;" 0b11110100;
+  assert_a "~0b00000110;" 0b011111001
 
 let test_binops _ =
   (* addition *)
@@ -117,11 +117,11 @@ let test_binops _ =
 
   (* bitwise and *)
   assert_a "0b1100 & 0b0101;" 0b0100;
-  assert_a "0b11110010 & 0b11;" 0b10;
+  assert_a "0b0110 & 0b11;" 0b10;
 
   (* bitwise or *)
   assert_a "0b1101 | 0b1010;" 0b1111;
-  assert_a "0b11110000 | 0b00101101;" 0b11111101;
+  assert_a "0b00001111 | 0b00101101;" 0b00101111;
 
   (* bitwise xor *)
   assert_a "0b1011 ^ 0b1110;" 0b0101;

--- a/programs/compiler_output/unrepresentable.3000.s
+++ b/programs/compiler_output/unrepresentable.3000.s
@@ -1,0 +1,3 @@
+	mvi 200, a
+	out a
+	hlt

--- a/programs/source/unrepresentable.3000.c
+++ b/programs/source/unrepresentable.3000.c
@@ -1,0 +1,6 @@
+
+#define ONE 1
+
+void main() {
+    print(200 + 55 + ONE);
+}


### PR DESCRIPTION
Fixes #8. 

I also updated the compiler CLI to typecheck both before _and_ after we optimize the AST, in order to catch unrepresentable constants that were computed during constant folding as well.