### PR TITLE
Immediate optimizations

### DIFF
--- a/TODO
+++ b/TODO
@@ -8,7 +8,7 @@ Compiler
       [x] constant folding 
         [] consider what happens on overflow
     During compile:
-      [] use more immediate instructions to reduce stack instructions
+      [x] use more immediate instructions to reduce stack instructions
 
 Docs
   [] document everything

--- a/lang/bin/assemble.ml
+++ b/lang/bin/assemble.ml
@@ -77,4 +77,4 @@ let command =
           else ()
         with err -> handle_err err source_text asm_filename)
 
-let () = Command.run ~version:"1.0" command
+let () = Command.run ~version:"1.0.0" command

--- a/lang/bin/compile.ml
+++ b/lang/bin/compile.ml
@@ -30,8 +30,6 @@ let command =
           let pgrm = Preprocess.preprocess pgrm in
           let pgrm = Desugar.desugar pgrm in
 
-          Printf.printf "After desugar:\n%s\n" (Prettyprint.pretty_print pgrm);
-
           (* On warnings, print them *)
           let warning_handler (w : compiler_warn) =
             print_warning (message_of_compiler_warn w source_text src_file)
@@ -49,9 +47,6 @@ let command =
               Dead_code_elimination.eliminate_dead_code
                 ~emit_warning:warning_handler pgrm
           in
-
-          Printf.printf "After optimizing AST:\n%s\n"
-            (Prettyprint.pretty_print pgrm);
 
           let instrs = Compile.compile pgrm ~ignore_asserts in
 
@@ -88,4 +83,4 @@ let command =
                 (Bytes.length assembled)
         with err -> handle_err err source_text src_file)
 
-let () = Command.run ~version:"1.0" command
+let () = Command.run ~version:"1.1.0" command

--- a/lang/bin/compile.ml
+++ b/lang/bin/compile.ml
@@ -6,6 +6,7 @@ open Asm.Warnings
 open Compiler.Optimizations
 open Compiler.Warnings
 open Err
+open Util
 
 (* command-line interface for compiler *)
 let command =
@@ -18,6 +19,8 @@ let command =
           ~doc:"binary_file emit compiled binary to file"
       and ignore_asserts =
         flag "-ignore-asserts" no_arg ~doc:"do not generate code for asserts"
+      and disable_opt =
+        flag "-disable-opt" no_arg ~doc:"do not apply extra optimizations"
       in
       fun () ->
         (* read input file into string *)
@@ -35,12 +38,16 @@ let command =
           in
 
           let pgrm = Check.check ~emit_warning:warning_handler pgrm in
+
           let pgrm =
-            Constant_fold.constant_fold ~emit_warning:warning_handler pgrm
+            if disable_opt then pgrm
+            else Constant_fold.constant_fold ~emit_warning:warning_handler pgrm
           in
           let pgrm =
-            Dead_code_elimination.eliminate_dead_code
-              ~emit_warning:warning_handler pgrm
+            if disable_opt then pgrm
+            else
+              Dead_code_elimination.eliminate_dead_code
+                ~emit_warning:warning_handler pgrm
           in
 
           Printf.printf "After optimizing AST:\n%s\n"
@@ -49,10 +56,17 @@ let command =
           let instrs = Compile.compile pgrm ~ignore_asserts in
 
           (* optimize the generated instructions *)
-          let instrs = Peephole.peephole_optimize instrs in
+          let instrs =
+            if disable_opt then instrs else Peephole.peephole_optimize instrs
+          in
 
           (* write generated asm to target file *)
           Out_channel.write_all target_file ~data:(string_of_instr_list instrs);
+
+          (* print message about generated code *)
+          Printf.printf "%s `%s` ==> `%s` (%d instructions)\n"
+            (Colors.success "Success!")
+            src_file target_file (List.length instrs);
 
           (* write binary also if requested *)
           match emit_binary with
@@ -65,7 +79,13 @@ let command =
               in
               let bin_out = Out_channel.create bin_file in
               Out_channel.output_bytes bin_out assembled;
-              Out_channel.close bin_out
+              Out_channel.close bin_out;
+
+              (* print message about assembled binary *)
+              Printf.printf "%s `%s` (%d instructions) ==> `%s` (%d bytes)\n"
+                (Colors.success "Success!")
+                target_file (List.length instrs) bin_file
+                (Bytes.length assembled)
         with err -> handle_err err source_text src_file)
 
 let () = Command.run ~version:"1.0" command

--- a/lang/bin/emulate.ml
+++ b/lang/bin/emulate.ml
@@ -30,4 +30,4 @@ let command =
           printf "%s\n" (Emulator__Machine.string_of_stew_3000 final_state)
         with err -> handle_err err source_text filename)
 
-let () = Command.run ~version:"1.0" command
+let () = Command.run ~version:"1.0.0" command


### PR DESCRIPTION
This makes the compiler use more immediate instructions instead of using the stack, when it can. Fixes #20. 